### PR TITLE
revert STR-1258 and remove l2 links

### DIFF
--- a/frontend/src/components/CheckpointDetails/index.tsx
+++ b/frontend/src/components/CheckpointDetails/index.tsx
@@ -18,7 +18,7 @@ const CheckpointDetails = () => {
   const [totalPages, setTotalPages] = useState(0);
   const [firstPage, setFirstPage] = useState(0);
   const rowsPerPage = 1; // Fixed value
-  const { apiBaseUrl, alpenExplorerBaseUrl, bitcoinExplorerBaseUrl } =
+  const { apiBaseUrl, bitcoinExplorerBaseUrl } =
     useConfig();
 
   useEffect(() => {
@@ -106,27 +106,15 @@ const CheckpointDetails = () => {
           </span>
         </div>
         <div className={styles.checkpointRow}>
-          <span className={styles.checkpointLabel}>Alpen start block:</span>
+          <span className={styles.checkpointLabel}>Strata start block:</span>
           <span className={styles.checkpointValue}>
-            <a
-              href={`${alpenExplorerBaseUrl}/block/${checkpoint.l2_range[0]}`}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {checkpoint.l2_range[0]}
-            </a>
+            {checkpoint.l2_range[0]}
           </span>
         </div>
         <div className={styles.checkpointRow}>
-          <span className={styles.checkpointLabel}>Alpen end block:</span>
+          <span className={styles.checkpointLabel}>Strata end block:</span>
           <span className={styles.checkpointValue}>
-            <a
-              href={`${alpenExplorerBaseUrl}/block/${checkpoint.l2_range[1]}`}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {checkpoint.l2_range[1]}
-            </a>
+            {checkpoint.l2_range[1]}
           </span>
         </div>
       </div>

--- a/frontend/src/components/Table/TableBody/index.tsx
+++ b/frontend/src/components/Table/TableBody/index.tsx
@@ -18,7 +18,6 @@ const TableBody: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(pageFromUrl);
   const {
     apiBaseUrl,
-    alpenExplorerBaseUrl,
     bitcoinExplorerBaseUrl,
     refreshIntervalS,
   } = useConfig();
@@ -78,8 +77,8 @@ const TableBody: React.FC = () => {
               <th className={styles.tableHeader}>Status</th>
               <th className={styles.tableHeader}>Signet start block</th>
               <th className={styles.tableHeader}>Signet end block</th>
-              <th className={styles.tableHeader}>Alpen start block</th>
-              <th className={styles.tableHeader}>Alpen end block</th>
+              <th className={styles.tableHeader}>Strata start block</th>
+              <th className={styles.tableHeader}>Strata end block</th>
             </tr>
           </thead>
           <tbody>
@@ -131,22 +130,10 @@ const TableBody: React.FC = () => {
                   </a>
                 </td>
                 <td className={styles.tableCell}>
-                  <a
-                    href={`${alpenExplorerBaseUrl}/block/${checkpoint.l2_range[0]}`}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {checkpoint.l2_range[0]}
-                  </a>
+                  {checkpoint.l2_range[0]}
                 </td>
                 <td className={styles.tableCell}>
-                  <a
-                    href={`${alpenExplorerBaseUrl}/block/${checkpoint.l2_range[1]}`}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {checkpoint.l2_range[1]}
-                  </a>
+                  {checkpoint.l2_range[1]}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
- Remove hyperlinks from Strata start/end block cells on list and detail pages. 
- Renames `Alpen` to `Strata`
Jira ticket [link](https://alpenlabs.atlassian.net/browse/STR-2578).

Screenshots from my local run:
<img width="1246" height="861" alt="Screenshot 2026-03-30 at 20 57 23" src="https://github.com/user-attachments/assets/dd30e0a1-35eb-4dd9-b082-7fa17b9ba635" />
<img width="1246" height="861" alt="Screenshot 2026-03-30 at 20 57 32" src="https://github.com/user-attachments/assets/7300aa99-d69b-442e-95d9-97f448f270a6" />
