### PR TITLE
Str 2540 explorer upgrade

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -359,9 +359,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "itoa",
  "matchit",
  "memchr",
@@ -373,9 +373,9 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -389,8 +389,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -458,11 +458,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -585,14 +585,21 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -692,6 +699,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +747,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -981,6 +1008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,9 +1069,9 @@ name = "fullnode-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "jsonrpsee",
  "migration",
  "model",
- "reqwest",
  "sea-orm",
  "serde",
  "serde_json",
@@ -1208,7 +1241,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1259,7 +1311,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.12",
  "httpdate",
  "mime",
  "sha1",
@@ -1271,7 +1323,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.12",
 ]
 
 [[package]]
@@ -1337,13 +1389,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1375,9 +1460,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1390,16 +1475,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "hyper-util",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1629,6 +1770,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.94",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1841,74 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "jsonrpsee-types",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.9",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
+dependencies = [
+ "base64 0.22.1",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
+ "hyper-rustls",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustls",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.9",
+ "tokio",
+ "tower 0.5.3",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
+dependencies = [
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -1838,10 +2091,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.5",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1950,7 +2203,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1975,6 +2228,12 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -2363,7 +2622,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2430,10 +2689,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2447,7 +2706,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2457,6 +2716,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2557,11 +2830,38 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2571,6 +2871,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2584,6 +2931,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2771,8 +3127,21 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2780,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2790,18 +3159,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2810,14 +3189,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3066,7 +3446,7 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -3113,7 +3493,7 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "crc",
@@ -3244,6 +3624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3261,7 +3647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3440,6 +3826,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,6 +3902,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,12 +3923,12 @@ checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "http-range-header",
  "httpdate",
  "iri-string",
@@ -3528,7 +3938,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3667,6 +4077,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3728,6 +4144,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -3828,6 +4254,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.6",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3854,6 +4298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3866,6 +4319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3893,6 +4355,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3928,6 +4405,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3940,6 +4423,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -3949,6 +4438,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3970,6 +4465,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -3979,6 +4480,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3994,6 +4501,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -4003,6 +4516,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4164,6 +4683,12 @@ dependencies = [
  "quote",
  "syn 2.0.94",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -32,3 +32,4 @@ hex = "0.4"
 sea-orm-migration = "0.9"
 config = "0.13"
 dotenvy = "0.15.7"
+jsonrpsee = { version = "0.26.0", features = ["http-client"] }

--- a/backend/bin/checkpoint-explorer/src/main.rs
+++ b/backend/bin/checkpoint-explorer/src/main.rs
@@ -13,9 +13,10 @@ use services::{
     block_service::run_block_fetcher,
     checkpoint_service::{start_checkpoint_fetcher, start_checkpoint_status_updater_task},
 };
+use model::checkpoint::L2BlockFetchTarget;
 use std::sync::Arc;
-use tokio::sync::mpsc;
-use tracing::info;
+use tokio::sync::watch;
+use tracing::{error, info};
 use tracing_subscriber::FmtSubscriber;
 use utils::config::Config;
 
@@ -40,27 +41,28 @@ async fn main() {
         .await
         .expect("Failed to run database migrations");
 
-    // Channels for communication between checkpoint fetcher and block fetcher
-    let (tx, rx) = mpsc::channel(100);
+    // Signals the block fetcher how far to fetch: carries the L2 end slot of
+    // the latest checkpoint processed by the checkpoint fetcher.
+    let (tx, rx) = watch::channel::<L2BlockFetchTarget>(0);
 
     // Start block fetcher task
     let fetcher_clone = fetcher.clone();
     let database_clone = database.clone();
-    tokio::spawn(async move {
+    let block_fetcher_handle = tokio::spawn(async move {
         run_block_fetcher(fetcher_clone, database_clone, rx).await;
     });
 
     // Start checkpoint fetcher task
     let fetcher_clone = fetcher.clone();
     let database_clone = database.clone();
-    tokio::spawn(async move {
+    let checkpoint_fetcher_handle = tokio::spawn(async move {
         start_checkpoint_fetcher(fetcher_clone, database_clone, tx, config.fetch_interval).await;
     });
 
     // Start checkpoint status updater task
     let fetcher_clone = fetcher.clone();
     let database_clone = database.clone();
-    tokio::spawn(async move {
+    let status_updater_handle = tokio::spawn(async move {
         start_checkpoint_status_updater_task(
             fetcher_clone,
             database_clone,
@@ -90,8 +92,14 @@ async fn main() {
     // Start the server
     let addr = format!("0.0.0.0:{}", config.server_port).parse().unwrap();
     info!(%addr, "Server started");
-    axum::Server::bind(&addr)
-        .serve(app.layer(cors).into_make_service())
-        .await
-        .unwrap();
+    let server = axum::Server::bind(&addr).serve(app.layer(cors).into_make_service());
+
+    // TODO: ideally use a service framework for lifecycle management in a follow up pr
+    tokio::select! {
+        res = block_fetcher_handle => { error!(?res, "block fetcher exited unexpectedly"); }
+        res = checkpoint_fetcher_handle => { error!(?res, "checkpoint fetcher exited unexpectedly"); }
+        res = status_updater_handle => { error!(?res, "status updater exited unexpectedly"); }
+        res = server => { error!(?res, "server exited unexpectedly"); }
+    }
+    std::process::exit(1);
 }

--- a/backend/bin/checkpoint-explorer/src/main.rs
+++ b/backend/bin/checkpoint-explorer/src/main.rs
@@ -8,12 +8,12 @@ use database::connection::DatabaseWrapper;
 use dotenvy::dotenv;
 use fullnode_client::fetcher::StrataFetcher;
 use migration::{Migrator, MigratorTrait};
+use model::checkpoint::L2BlockFetchTarget;
 use reqwest::Method;
 use services::{
     block_service::run_block_fetcher,
     checkpoint_service::{start_checkpoint_fetcher, start_checkpoint_status_updater_task},
 };
-use model::checkpoint::L2BlockFetchTarget;
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::{error, info};

--- a/backend/bin/checkpoint-explorer/src/services/block_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/block_service.rs
@@ -1,70 +1,56 @@
 use database::connection::DatabaseWrapper;
-use database::services::{block_service::BlockService, checkpoint_service::CheckpointService};
+use database::services::block_service::BlockService;
 use fullnode_client::fetcher::StrataFetcher;
-use model::block::RpcBlockHeader;
+use model::checkpoint::L2BlockFetchTarget;
 use std::sync::Arc;
-use tokio::sync::mpsc::Receiver;
-use tracing::{debug, info};
+use tokio::sync::watch::Receiver;
+use tracing::{error, info};
 
-/// Event sent to block fetcher to request fetching of blocks for the checkpoint
-#[derive(Debug, Clone)]
-pub struct CheckpointFetch {
-    pub idx: u64,
-}
-impl CheckpointFetch {
-    pub fn new(idx: u64) -> Self {
-        Self { idx }
-    }
-}
+const MAX_HEADERS_RANGE: u64 = 5000;
+
 pub async fn run_block_fetcher(
     fetcher: Arc<StrataFetcher>,
     database: Arc<DatabaseWrapper>,
-    mut rx: Receiver<CheckpointFetch>,
+    mut rx: Receiver<L2BlockFetchTarget>,
 ) {
     info!("Starting block fetcher...");
-    while let Some(CheckpointFetch { idx }) = rx.recv().await {
-        debug!(idx, "Received checkpoint");
-        fetch_blocks_in_checkpoint(fetcher.clone(), database.clone(), idx).await;
+    loop {
+        if rx.changed().await.is_err() {
+            break;
+        }
+        let target = *rx.borrow_and_update();
+        fetch_blocks(fetcher.clone(), database.clone(), target).await;
     }
 }
 
-async fn fetch_blocks_in_checkpoint(
-    fetcher: Arc<StrataFetcher>,
-    database: Arc<DatabaseWrapper>,
-    checkpoint_idx: u64,
-) {
-    let checkpoint_db = CheckpointService::new(&database.db);
+async fn fetch_blocks(fetcher: Arc<StrataFetcher>, database: Arc<DatabaseWrapper>, target: u64) {
     let block_db = BlockService::new(&database.db);
-    let checkpoint = checkpoint_db.get_checkpoint_by_idx(checkpoint_idx).await;
-    if let Some(c) = checkpoint {
-        let mut start = c.l2_range.0;
-        let end = c.l2_range.1;
+    let start = block_db
+        .get_latest_block_index()
+        .await
+        .map(|h| h + 1)
+        .unwrap_or(0);
 
-        // we will reach this point only when we are sure that we must fetch from particular
-        // checkpoint. So having the highest among the blocks must give us the shortcut
-        // to determine the most optimal starting point.
-        let last_block = block_db.get_latest_block_index().await;
-        if let Some(last_block_height) = last_block {
-            // start from the next block
-            if last_block_height >= start {
-                start = last_block_height + 1;
-            }
-        }
-        if start > end {
-            info!(checkpoint_idx, "No blocks to fetch");
-            return;
-        }
-        info!(start, end, checkpoint_idx, "Fetching blocks");
-        for block_height in start..=end {
-            if let Ok(block_headers) = fetcher
-                .fetch_data::<Vec<RpcBlockHeader>>("strata_getHeadersAtIdx", block_height)
-                .await
-            {
-                for block_header in block_headers {
-                    block_db
-                        .insert_block(block_header.clone(), checkpoint_idx)
-                        .await;
+    if start > target {
+        info!("No blocks to fetch");
+        return;
+    }
+
+    let mut cursor = start;
+    info!(cursor, target, "Fetching blocks");
+    while cursor <= target {
+        let chunk_end = (cursor + MAX_HEADERS_RANGE - 1).min(target);
+        match fetcher.fetch_headers_in_range(cursor, chunk_end).await {
+            Ok(headers) => {
+                for header in headers {
+                    let checkpoint_idx = header.epoch;
+                    block_db.insert_block(header, checkpoint_idx).await;
                 }
+                cursor = chunk_end + 1;
+            }
+            Err(e) => {
+                error!(?e, cursor, chunk_end, "Failed to fetch block headers");
+                return;
             }
         }
     }

--- a/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
@@ -1,11 +1,10 @@
-use crate::services::block_service::CheckpointFetch;
 use database::connection::DatabaseWrapper;
 use database::services::{block_service::BlockService, checkpoint_service::CheckpointService};
 use fullnode_client::fetcher::StrataFetcher;
-use model::checkpoint::{RpcCheckpointConfStatus, RpcCheckpointInfo};
+use model::checkpoint::{L2BlockFetchTarget, RpcCheckpointConfStatus, RpcCheckpointInfo};
 use std::cmp::min;
 use std::sync::Arc;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::watch::Sender;
 use tracing::{error, info, warn};
 
 /// This function fetches the checkpoints from the fullnode and inserts them into the database
@@ -13,7 +12,7 @@ use tracing::{error, info, warn};
 pub async fn start_checkpoint_fetcher(
     fetcher: Arc<StrataFetcher>,
     database: Arc<DatabaseWrapper>,
-    tx: Sender<CheckpointFetch>,
+    tx: Sender<L2BlockFetchTarget>,
     fetch_interval: u64,
 ) {
     info!("Starting checkpoint fetcher...");
@@ -33,19 +32,14 @@ pub async fn start_checkpoint_fetcher(
 async fn fetch_checkpoints(
     fetcher: Arc<StrataFetcher>,
     database: Arc<DatabaseWrapper>,
-    tx: Sender<CheckpointFetch>,
+    tx: Sender<L2BlockFetchTarget>,
 ) -> anyhow::Result<()> {
     let checkpoint_db = CheckpointService::new(&database.db);
     info!("Fetching checkpoints from fullnode...");
-    let fullnode_last_checkpoint = fetcher
-        .get_latest_index("strata_getLatestCheckpointIndex")
-        .await?;
-    // handle None case
-    if fullnode_last_checkpoint.is_none() {
-        warn!("Failed to fetch latest checkpoint index from fullnode or no checkpoint yet.");
-        return Ok(());
-    }
-    let fn_chkpt = fullnode_last_checkpoint.unwrap();
+
+    let chain_status = fetcher.get_chain_status().await?;
+    let fn_chkpt = chain_status.confirmed.epoch;
+
     let starting_checkpoint = get_starting_checkpoint_idx(database.clone()).await?;
     info!(
         fullnode_latest = fn_chkpt,
@@ -59,12 +53,16 @@ async fn fetch_checkpoints(
                 .fetch_data::<RpcCheckpointInfo>("strata_getCheckpointInfo", idx)
                 .await
             {
-                checkpoint_db.insert_checkpoint(checkpoint.clone()).await;
+                checkpoint_db.insert_checkpoint(checkpoint).await;
             }
         }
-        let range = CheckpointFetch::new(idx);
-        tx.send(range).await?;
     }
+
+    // notify block fetcher with the l2_end of the latest confirmed checkpoint
+    if let Some(latest) = checkpoint_db.get_checkpoint_by_idx(fn_chkpt).await {
+        let _ = tx.send(latest.l2_range.1);
+    }
+
     Ok(())
 }
 
@@ -108,7 +106,7 @@ pub async fn start_checkpoint_status_updater_task(
     // Spawn the "pending" checkpoint updater loop
     let fetcher_clone = fetcher.clone();
     let database_clone = database.clone();
-    tokio::spawn(async move {
+    let pending_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(update_interval));
 
         loop {
@@ -131,7 +129,7 @@ pub async fn start_checkpoint_status_updater_task(
     });
 
     // Spawn the "confirmed" checkpoint updater loop
-    tokio::spawn(async move {
+    let confirmed_handle = tokio::spawn(async move {
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(update_interval));
 
         loop {
@@ -152,6 +150,12 @@ pub async fn start_checkpoint_status_updater_task(
             }
         }
     });
+
+    // TODO: ideally use a service framework for lifecycle management in a follow up pr
+    tokio::select! {
+        res = pending_handle => { error!(?res, "pending status updater exited unexpectedly"); }
+        res = confirmed_handle => { error!(?res, "confirmed status updater exited unexpectedly"); }
+    }
 }
 
 /// This function continuously updates the status of the checkpoints which are yet to be finalized.
@@ -211,13 +215,7 @@ async fn update_checkpoints_status(
             return Ok(());
         };
 
-        let new_status = match checkpoint_from_rpc.confirmation_status {
-            Some(s) => s,
-            None => {
-                warn!(idx, "Checkpoint status is None");
-                return Ok(()); // Simply return and continue execution instead of erroring
-            }
-        };
+        let new_status = checkpoint_from_rpc.status();
 
         // if there is no change in status, return by doing nothing
         if checkpoint_in_db.confirmation_status == Some(new_status) {

--- a/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
@@ -66,7 +66,7 @@ async fn fetch_checkpoints(
 /// It is a helper function that returns the starting checkpoint index to start fetching from
 /// It will return the minimum of the last checkpoint in the database and the checkpoint corresponding to
 /// last block in the database
-async fn get_starting_checkpoint_idx(db: Arc<DatabaseWrapper>) -> anyhow::Result<u64> {
+async fn get_starting_checkpoint_idx(db: Arc<DatabaseWrapper>) -> anyhow::Result<u32> {
     let checkpoint_db = CheckpointService::new(&db.db);
     let block_db = BlockService::new(&db.db);
 
@@ -80,7 +80,7 @@ async fn get_starting_checkpoint_idx(db: Arc<DatabaseWrapper>) -> anyhow::Result
 
     // we are calling it probable_* to consider some weirdest condition when
     // we have the block but no any earlier checkpoint (before where block corresponds)
-    let probable_starting_checkpoint: u64 = if let Some(block_height) = last_block {
+    let probable_starting_checkpoint: u32 = if let Some(block_height) = last_block {
         checkpoint_db
             .get_checkpoint_idx_by_block_height(block_height)
             .await?
@@ -174,7 +174,7 @@ async fn update_checkpoints_status(
 ) -> anyhow::Result<()> {
     let checkpoint_db = CheckpointService::new(&database.db);
 
-    let mut idx: u64 = match status {
+    let mut idx: u32 = match status {
         RpcCheckpointConfStatus::Pending => {
             match checkpoint_db.get_earliest_pending_checkpoint_idx().await {
                 Some(i) => i,

--- a/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
@@ -1,7 +1,7 @@
 use database::connection::DatabaseWrapper;
 use database::services::{block_service::BlockService, checkpoint_service::CheckpointService};
 use fullnode_client::fetcher::StrataFetcher;
-use model::checkpoint::{L2BlockFetchTarget, RpcCheckpointConfStatus, RpcCheckpointInfo};
+use model::checkpoint::{L2BlockFetchTarget, RpcCheckpointConfStatus};
 use std::cmp::min;
 use std::sync::Arc;
 use tokio::sync::watch::Sender;
@@ -49,10 +49,7 @@ async fn fetch_checkpoints(
     for idx in starting_checkpoint..=fn_chkpt {
         if !checkpoint_db.checkpoint_exists(idx).await {
             info!(idx, "Checkpoint not in db, fetching");
-            if let Ok(checkpoint) = fetcher
-                .fetch_data::<RpcCheckpointInfo>("strata_getCheckpointInfo", idx)
-                .await
-            {
+            if let Ok(checkpoint) = fetcher.fetch_checkpoint_info(idx).await {
                 checkpoint_db.insert_checkpoint(checkpoint).await;
             }
         }
@@ -207,10 +204,7 @@ async fn update_checkpoints_status(
             return Ok(());
         };
 
-        let Ok(checkpoint_from_rpc) = fetcher
-            .fetch_data::<RpcCheckpointInfo>("strata_getCheckpointInfo", idx)
-            .await
-        else {
+        let Ok(checkpoint_from_rpc) = fetcher.fetch_checkpoint_info(idx).await else {
             warn!(idx, "Checkpoint not found in fullnode");
             return Ok(());
         };

--- a/backend/database/src/services/block_service.rs
+++ b/backend/database/src/services/block_service.rs
@@ -12,7 +12,7 @@ impl<'a> BlockService<'a> {
         Self { db }
     }
 
-    pub async fn insert_block(&self, rpc_block_header: RpcBlockHeader, checkpoint_idx: u64) {
+    pub async fn insert_block(&self, rpc_block_header: RpcBlockHeader, checkpoint_idx: u32) {
         // Use `From` to convert `RpcBlockHeader` into an `ActiveModel`
         let mut active_model: BlockActiveModel = rpc_block_header.into();
 

--- a/backend/database/src/services/block_service.rs
+++ b/backend/database/src/services/block_service.rs
@@ -1,5 +1,5 @@
 use model::block::{ActiveModel as BlockActiveModel, Entity as Block, RpcBlockHeader};
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QuerySelect, Set};
+use sea_orm::{ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter, QuerySelect, Set};
 use tracing::{debug, error};
 
 /// Wrapper around the database connection
@@ -19,14 +19,10 @@ impl<'a> BlockService<'a> {
         let height = active_model.height.clone().unwrap();
         let block_id = active_model.block_hash.clone().unwrap();
 
-        // If block already exists locally do nothing
-        if self.block_exists(height).await {
-            debug!(height, "Block already exists");
-            return;
-        }
         // ensure that blocks exist incrementally and continuously
         let can_insert_block = self.can_insert_block(height).await;
         if !can_insert_block {
+            // TODO(STR-1454): handle this gracefully using service framework
             panic!("last_block_height does not match the expected height!");
         }
 
@@ -36,6 +32,9 @@ impl<'a> BlockService<'a> {
         match Block::insert(active_model).exec(self.db).await {
             Ok(_) => {
                 debug!(height, %block_id, "Block inserted and indexed");
+            }
+            Err(err) if is_duplicate_entry(&err) => {
+                debug!(height, "Block already exists, skipping");
             }
             Err(err) => {
                 error!(height, ?err, "Failed to insert block");
@@ -88,4 +87,8 @@ impl<'a> BlockService<'a> {
         }
         self.prev_block_exists(height).await
     }
+}
+
+fn is_duplicate_entry(err: &DbErr) -> bool {
+    err.to_string().contains("1062")
 }

--- a/backend/database/src/services/checkpoint_service.rs
+++ b/backend/database/src/services/checkpoint_service.rs
@@ -21,7 +21,7 @@ impl<'a> CheckpointService<'a> {
         Self { db }
     }
 
-    pub async fn checkpoint_exists(&self, idx: u64) -> bool {
+    pub async fn checkpoint_exists(&self, idx: u32) -> bool {
         Checkpoint::find()
             .filter(model::checkpoint::Column::Idx.eq(idx))
             .one(self.db)
@@ -32,7 +32,7 @@ impl<'a> CheckpointService<'a> {
 
     /// Insert a new checkpoint into the database
     pub async fn insert_checkpoint(&self, checkpoint: RpcCheckpointInfo) {
-        let idx: u64 = checkpoint.idx;
+        let idx: u32 = checkpoint.idx;
 
         // for the first checkpoint (idx=0), no need to check the previous checkpoint
         if let Some(previous_idx) = idx.checked_sub(1) {
@@ -57,7 +57,7 @@ impl<'a> CheckpointService<'a> {
     }
 
     /// Fetch a checkpoint by its index
-    pub async fn get_checkpoint_by_idx(&self, idx: u64) -> Option<RpcCheckpointInfoCheckpointExp> {
+    pub async fn get_checkpoint_by_idx(&self, idx: u32) -> Option<RpcCheckpointInfoCheckpointExp> {
         match Checkpoint::find()
             .filter(model::checkpoint::Column::Idx.eq(idx))
             .one(self.db)
@@ -76,7 +76,7 @@ impl<'a> CheckpointService<'a> {
     pub async fn get_checkpoint_idx_by_block_hash(
         &self,
         block_hash: &str,
-    ) -> Result<Option<u64>, DbErr> {
+    ) -> Result<Option<u32>, DbErr> {
         match Block::find()
             .filter(model::block::Column::BlockHash.eq(block_hash))
             .one(self.db)
@@ -101,7 +101,7 @@ impl<'a> CheckpointService<'a> {
     pub async fn get_checkpoint_idx_by_block_height(
         &self,
         block_height: u64,
-    ) -> Result<Option<u64>, DbErr> {
+    ) -> Result<Option<u32>, DbErr> {
         debug!(block_height, "Searching for block");
 
         match Block::find()
@@ -175,13 +175,13 @@ impl<'a> CheckpointService<'a> {
     }
 
     /// Get the latest checkpoint index stored in the database
-    pub async fn get_latest_checkpoint_index(&self) -> Option<u64> {
+    pub async fn get_latest_checkpoint_index(&self) -> Option<u32> {
         use sea_orm::entity::prelude::*;
 
         match Checkpoint::find()
             .select_only()
             .column_as(model::checkpoint::Column::Idx.max(), "max_idx")
-            .into_tuple::<Option<u64>>()
+            .into_tuple::<Option<u32>>()
             .one(self.db)
             .await
         {
@@ -195,7 +195,7 @@ impl<'a> CheckpointService<'a> {
     }
 
     /// Get the earliest checkpoint index whose status is either `Pending` or `Confirmed`
-    pub async fn get_earliest_unfinalized_checkpoint_idx(&self) -> Option<u64> {
+    pub async fn get_earliest_unfinalized_checkpoint_idx(&self) -> Option<u32> {
         // add the condition to check no checkpoint at all
         self.get_latest_checkpoint_index().await?;
         match Checkpoint::find()
@@ -213,7 +213,7 @@ impl<'a> CheckpointService<'a> {
         }
     }
     /// Get the earliest checkpoint index whose status is `Pending`
-    pub async fn get_earliest_pending_checkpoint_idx(&self) -> Option<u64> {
+    pub async fn get_earliest_pending_checkpoint_idx(&self) -> Option<u32> {
         // add the condition to check no checkpoint at all
         self.get_latest_checkpoint_index().await?;
         match Checkpoint::find()
@@ -231,7 +231,7 @@ impl<'a> CheckpointService<'a> {
         }
     }
     /// Get the earliest checkpoint index whose status is `Confirmed`
-    pub async fn get_earliest_confirmed_checkpoint_idx(&self) -> Option<u64> {
+    pub async fn get_earliest_confirmed_checkpoint_idx(&self) -> Option<u32> {
         // add the condition to check no checkpoint at all
         self.get_latest_checkpoint_index().await?;
         match Checkpoint::find()
@@ -249,7 +249,7 @@ impl<'a> CheckpointService<'a> {
         }
     }
     /// Get the last checkpoint index whose status is `Finalized`
-    pub async fn get_last_finalized_checkpoint_idx(&self) -> Option<u64> {
+    pub async fn get_last_finalized_checkpoint_idx(&self) -> Option<u32> {
         // add the condition to check no checkpoint at all
         self.get_latest_checkpoint_index().await?;
         match Checkpoint::find()
@@ -270,7 +270,7 @@ impl<'a> CheckpointService<'a> {
     /// Update the status of a checkpoint
     pub async fn update_checkpoint(
         &self,
-        checkpoint_idx: u64,
+        checkpoint_idx: u32,
         updated_checkpoint: RpcCheckpointInfo,
     ) -> Result<(), DbErr> {
         match Checkpoint::find()

--- a/backend/fullnode-client/Cargo.toml
+++ b/backend/fullnode-client/Cargo.toml
@@ -14,7 +14,7 @@ tracing.workspace = true
 sea-orm.workspace = true
 serde.workspace = true
 anyhow.workspace = true
-reqwest.workspace = true
+jsonrpsee.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]

--- a/backend/fullnode-client/fetcher.rs
+++ b/backend/fullnode-client/fetcher.rs
@@ -1,125 +1,62 @@
-use anyhow::{Context, Result};
-use reqwest::Client;
-use serde_json::{json, Value};
-use tracing::{debug, error, info};
+use anyhow::Result;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use jsonrpsee::rpc_params;
+use model::block::RpcBlockHeader;
+use model::checkpoint::RpcOLChainStatus;
+use tracing::error;
+
 /// `StrataFetcher` struct for fetching checkpoint and block data
 pub struct StrataFetcher {
-    client: Client,
-    endpoint: String, // Fullnode base URL
+    client: HttpClient,
 }
 
 impl StrataFetcher {
     /// Creates a new `StrataFetcher` instance.
     pub fn new(endpoint: String) -> Self {
-        Self {
-            client: Client::new(),
-            endpoint,
-        }
-    }
-
-    /// Fetches the latest index (checkpoint or block) based on the method name.
-    ///
-    /// # Parameters
-    /// * `method` - JSON-RPC method name (e.g., `strata_getLatestCheckpointIndex`)
-    ///
-    /// # Returns
-    /// * `Result<u64>` - Latest index if successful
-    pub async fn get_latest_index(&self, method: &str) -> Result<Option<u64>> {
-        let payload = json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": [],
-            "id": 1
-        });
-
-        let response = self
-            .client
-            .post(&self.endpoint)
-            .json(&payload)
-            .send()
-            .await
-            .with_context(|| format!("Failed to send {method} request"))?;
-
-        let status = response.status();
-        let text = response
-            .text()
-            .await
-            .context("Failed to read response body")?;
-
-        if !status.is_success() {
-            error!(endpoint = %self.endpoint, %status, "Request failed");
-            debug!(body = %text, "Response body");
-            return Err(anyhow::anyhow!(
-                "Request returned an error status: {} - {}",
-                status,
-                text
-            ));
-        }
-
-        let json_response: Value =
-            serde_json::from_str(&text).context("Failed to parse JSON response")?;
-
-        match json_response.get("result") {
-            Some(Value::Null) => {
-                info!("No latest index found");
-                Ok(None)
-            }
-            Some(Value::Number(n)) => n.as_u64().map(Some).ok_or_else(|| {
-                anyhow::anyhow!("Invalid numeric format in response: {}", json_response)
-            }),
-            _ => Err(anyhow::anyhow!(
-                "Unexpected response format: {}",
-                json_response
-            )),
-        }
+        let client = HttpClientBuilder::default()
+            .build(&endpoint)
+            .expect("Failed to build HTTP client");
+        Self { client }
     }
 
     /// Fetches detailed information for a given index (checkpoint or block).
-    ///
-    /// # Parameters
-    /// * `method` - JSON-RPC method name (e.g., `strata_getCheckpointInfo`)
-    /// * `idx` - Index to fetch
-    ///
-    /// # Returns
-    /// * `Result<T>` - Fetched data deserialized into the generic type `T`
     pub async fn fetch_data<T>(&self, method: &str, idx: u64) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
     {
-        let payload = json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": [idx],
-            "id": 1
-        });
-
-        let response: Value = self
-            .client
-            .post(&self.endpoint)
-            .json(&payload)
-            .send()
+        self.client
+            .request(method, rpc_params![idx])
             .await
-            .context("Failed to send request")?
-            .error_for_status()
-            .context("Request returned an error status")?
-            .json()
-            .await
-            .context("Failed to parse JSON response")?;
+            .map_err(|e| {
+                error!(method, idx, ?e, "RPC call failed");
+                anyhow::anyhow!("RPC call failed: {:?}", e)
+            })
+    }
 
-        match response.get("result") {
-            Some(Value::Null) | None => {
-                anyhow::bail!("No data exists for index ID: {}", idx);
-            }
-            Some(result) => match serde_json::from_value::<T>(result.clone()) {
-                Ok(data) => Ok(data),
-                Err(e) => {
-                    error!(idx, ?e, "Deserialization failed");
-                    Err(anyhow::anyhow!(
-                        "Failed to deserialize response data: {:?}",
-                        e
-                    ))
-                }
-            },
-        }
+    /// Fetches the current OL chain status via strata_getChainStatus.
+    pub async fn get_chain_status(&self) -> Result<RpcOLChainStatus> {
+        self.client
+            .request("strata_getChainStatus", rpc_params![])
+            .await
+            .map_err(|e| {
+                error!(?e, "strata_getChainStatus failed");
+                anyhow::anyhow!("strata_getChainStatus failed: {:?}", e)
+            })
+    }
+
+    /// Fetches block headers for a slot range via strata_getHeadersInRange.
+    pub async fn fetch_headers_in_range(
+        &self,
+        start: u64,
+        end: u64,
+    ) -> Result<Vec<RpcBlockHeader>> {
+        self.client
+            .request("strata_getHeadersInRange", rpc_params![start, end])
+            .await
+            .map_err(|e| {
+                error!(start, end, ?e, "strata_getHeadersInRange failed");
+                anyhow::anyhow!("strata_getHeadersInRange failed: {:?}", e)
+            })
     }
 }

--- a/backend/fullnode-client/fetcher.rs
+++ b/backend/fullnode-client/fetcher.rs
@@ -3,7 +3,7 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::rpc_params;
 use model::block::RpcBlockHeader;
-use model::checkpoint::RpcOLChainStatus;
+use model::checkpoint::{RpcCheckpointInfo, RpcOLChainStatus};
 use tracing::error;
 
 /// `StrataFetcher` struct for fetching checkpoint and block data
@@ -20,17 +20,14 @@ impl StrataFetcher {
         Self { client }
     }
 
-    /// Fetches detailed information for a given index (checkpoint or block).
-    pub async fn fetch_data<T>(&self, method: &str, idx: u64) -> Result<T>
-    where
-        T: serde::de::DeserializeOwned,
-    {
+    /// Fetches checkpoint info for a given index via strata_getCheckpointInfo.
+    pub async fn fetch_checkpoint_info(&self, idx: u64) -> Result<RpcCheckpointInfo> {
         self.client
-            .request(method, rpc_params![idx])
+            .request("strata_getCheckpointInfo", rpc_params![idx])
             .await
             .map_err(|e| {
-                error!(method, idx, ?e, "RPC call failed");
-                anyhow::anyhow!("RPC call failed: {:?}", e)
+                error!(idx, ?e, "strata_getCheckpointInfo failed");
+                anyhow::anyhow!("strata_getCheckpointInfo failed: {:?}", e)
             })
     }
 

--- a/backend/fullnode-client/fetcher.rs
+++ b/backend/fullnode-client/fetcher.rs
@@ -21,7 +21,7 @@ impl StrataFetcher {
     }
 
     /// Fetches checkpoint info for a given index via strata_getCheckpointInfo.
-    pub async fn fetch_checkpoint_info(&self, idx: u64) -> Result<RpcCheckpointInfo> {
+    pub async fn fetch_checkpoint_info(&self, idx: u32) -> Result<RpcCheckpointInfo> {
         self.client
             .request("strata_getCheckpointInfo", rpc_params![idx])
             .await

--- a/backend/model/src/block.rs
+++ b/backend/model/src/block.rs
@@ -10,7 +10,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub block_hash: String,
     pub height: u64,
-    pub checkpoint_idx: u64,
+    pub checkpoint_idx: u32,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -33,7 +33,7 @@ impl From<RpcBlockHeader> for ActiveModel {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RpcBlockHeader {
     pub slot: u64,
-    pub epoch: u64,
+    pub epoch: u32,
     pub blkid: L2BlockId,
     pub timestamp: u64,
     pub parent_blkid: L2BlockId,

--- a/backend/model/src/block.rs
+++ b/backend/model/src/block.rs
@@ -1,5 +1,6 @@
+use crate::checkpoint::{HexBytes32, L2BlockId};
 use sea_orm::entity::prelude::*;
-use sea_orm::ActiveValue::{NotSet, Set};
+use sea_orm::ActiveValue::Set;
 use serde::{Deserialize, Serialize};
 
 /// Represents the Block model for the database
@@ -21,34 +22,23 @@ impl ActiveModelBehavior for ActiveModel {}
 impl From<RpcBlockHeader> for ActiveModel {
     fn from(header: RpcBlockHeader) -> Self {
         Self {
-            block_hash: Set(header.block_id),
-            height: Set(header.block_idx),
-            checkpoint_idx: NotSet,
+            block_hash: Set(header.blkid),
+            height: Set(header.slot),
+            checkpoint_idx: Set(header.epoch),
         }
     }
 }
 
-/// Represents a block header as returned by Strata fullnode
+/// Represents a block header as returned by strata_getHeadersInRange
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RpcBlockHeader {
-    /// The index of the block representing height.
-    pub block_idx: u64,
-
-    /// The timestamp of when the block was created in UNIX epoch format.
+    pub slot: u64,
+    pub epoch: u64,
+    pub blkid: L2BlockId,
     pub timestamp: u64,
-
-    /// hash of the block's contents.
-    pub block_id: String,
-
-    /// previous block
-    pub prev_block: String,
-
-    /// L1 segment hash
-    pub l1_segment_hash: String,
-
-    /// Hash of the execution segment
-    pub exec_segment_hash: String,
-
-    /// The root hash of the state tree
-    pub state_root: String,
+    pub parent_blkid: L2BlockId,
+    pub state_root: HexBytes32,
+    pub body_root: HexBytes32,
+    pub logs_root: HexBytes32,
+    pub is_terminal: bool,
 }

--- a/backend/model/src/checkpoint.rs
+++ b/backend/model/src/checkpoint.rs
@@ -9,6 +9,11 @@ use std::str::FromStr;
 pub type L2BlockId = String;
 pub type L1BlockId = String;
 pub type Txid = String;
+pub type HexBytes32 = String;
+
+/// The L2 slot number up to which the block fetcher should fetch blocks.
+/// Sent over the watch channel from the checkpoint fetcher to the block fetcher.
+pub type L2BlockFetchTarget = u64;
 
 /// Represents the checkpoint information returned by the RPC.
 /// Name for this struct comes from the Strata RPC endpoint.
@@ -20,10 +25,22 @@ pub struct RpcCheckpointInfo {
     pub l1_range: (L1BlockCommitment, L1BlockCommitment),
     /// The L2 height range that the checkpoint covers (start, end)
     pub l2_range: (L2BlockCommitment, L2BlockCommitment),
-    /// Info on txn where checkpoint is committed on chain
-    pub l1_reference: Option<RpcCheckpointL1Ref>,
-    /// Confirmation status of checkpoint
-    pub confirmation_status: Option<RpcCheckpointConfStatus>,
+    confirmation_status: ConfStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcCheckpointL1Ref {
+    pub l1_block: L1BlockCommitment,
+    pub txid: Txid,
+    pub wtxid: Txid,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum ConfStatus {
+    Pending,
+    Confirmed { l1_reference: RpcCheckpointL1Ref },
+    Finalized { l1_reference: RpcCheckpointL1Ref },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -33,18 +50,20 @@ pub struct L1BlockCommitment {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Buf32(pub [u8; 32]);
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct RpcCheckpointL1Ref {
-    pub block_height: u64,
-    pub block_id: String,
-    pub txid: String,
-    pub wtxid: String,
-}
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct L2BlockCommitment {
-    slot: u64,
-    blkid: L2BlockId,
+    pub slot: u64,
+    pub blkid: L2BlockId,
+}
+
+/// Wire type for strata_getChainStatus (only fields we use).
+#[derive(Debug, Deserialize)]
+pub struct RpcOLChainStatus {
+    pub confirmed: EpochCommitment,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EpochCommitment {
+    pub epoch: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, EnumIter, DeriveActiveEnum)]
@@ -104,18 +123,37 @@ pub struct Model {
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}
 
+impl RpcCheckpointInfo {
+    pub fn status(&self) -> RpcCheckpointConfStatus {
+        match &self.confirmation_status {
+            ConfStatus::Pending => RpcCheckpointConfStatus::Pending,
+            ConfStatus::Confirmed { .. } => RpcCheckpointConfStatus::Confirmed,
+            ConfStatus::Finalized { .. } => RpcCheckpointConfStatus::Finalized,
+        }
+    }
+}
+
 impl From<RpcCheckpointInfo> for ActiveModel {
     fn from(info: RpcCheckpointInfo) -> Self {
+        let (status, txid) = match &info.confirmation_status {
+            ConfStatus::Pending => (RpcCheckpointConfStatus::Pending, None),
+            ConfStatus::Confirmed { l1_reference } => (
+                RpcCheckpointConfStatus::Confirmed,
+                Some(l1_reference.txid.clone()),
+            ),
+            ConfStatus::Finalized { l1_reference } => (
+                RpcCheckpointConfStatus::Finalized,
+                Some(l1_reference.txid.clone()),
+            ),
+        };
         Self {
             idx: Set(info.idx),
             l1_start: Set(info.l1_range.0.height),
             l1_end: Set(info.l1_range.1.height),
             l2_start: Set(info.l2_range.0.slot),
             l2_end: Set(info.l2_range.1.slot),
-            checkpoint_txid: Set(info.l1_reference.as_ref().map(|c| c.txid.clone())),
-            status: Set(info
-                .confirmation_status
-                .unwrap_or(RpcCheckpointConfStatus::Pending)),
+            checkpoint_txid: Set(txid),
+            status: Set(status),
         }
     }
 }

--- a/backend/model/src/checkpoint.rs
+++ b/backend/model/src/checkpoint.rs
@@ -20,7 +20,7 @@ pub type L2BlockFetchTarget = u64;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RpcCheckpointInfo {
     /// The index of the checkpoint
-    pub idx: u64,
+    pub idx: u32,
     /// The L1 height range that the checkpoint covers (start, end)
     pub l1_range: (L1BlockCommitment, L1BlockCommitment),
     /// The L2 height range that the checkpoint covers (start, end)
@@ -63,7 +63,7 @@ pub struct RpcOLChainStatus {
 
 #[derive(Debug, Deserialize)]
 pub struct EpochCommitment {
-    pub epoch: u64,
+    pub epoch: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, EnumIter, DeriveActiveEnum)]
@@ -111,7 +111,7 @@ impl Display for RpcCheckpointConfStatus {
 #[sea_orm(table_name = "checkpoints")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
-    pub idx: u64,
+    pub idx: u32,
     pub l1_start: u64,
     pub l1_end: u64,
     pub l2_start: u64,
@@ -168,7 +168,7 @@ pub struct ExplorerL1Ref {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RpcCheckpointInfoCheckpointExp {
     /// The index of the checkpoint
-    pub idx: u64,
+    pub idx: u32,
     /// The L1 height range that the checkpoint covers (start, end)
     pub l1_range: (u64, u64),
     /// The L2 height range that the checkpoint covers (start, end)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     container_name: checkpoint_explorer_backend
     environment:
       APP_DATABASE_URL: mysql://explorer:password@mariadb:3306/checkpoint_explorer_db
-      STRATA_FULLNODE: "https://rpc.testnet-staging.stratabtc.org/"
+      STRATA_FULLNODE: "http://host.docker.internal:8432"
       APP_FETCH_INTERVAL: 5
       RUST_LOG: "info,sqlx::query=warn"
     ports:

--- a/functional-tests/envs/services/mock_fullnode.py
+++ b/functional-tests/envs/services/mock_fullnode.py
@@ -40,12 +40,12 @@ class _MockServer(HTTPServer):
         self._bpc = blocks_per_checkpoint
 
     def dispatch(self, method: str, params: list):
-        if method == "strata_getLatestCheckpointIndex":
-            return self._n - 1
+        if method == "strata_getChainStatus":
+            return {"confirmed": {"epoch": self._n - 1}}
         if method == "strata_getCheckpointInfo":
             return self._checkpoint_info(int(params[0]))
-        if method == "strata_getHeadersAtIdx":
-            return self._headers_at_idx(int(params[0]))
+        if method == "strata_getHeadersInRange":
+            return self._headers_in_range(int(params[0]), int(params[1]))
         return None
 
     def _checkpoint_info(self, idx: int):
@@ -57,13 +57,19 @@ class _MockServer(HTTPServer):
         l1_start = idx * 10
         l1_end = l1_start + 9
 
+        l1_ref = {
+            "l1_block": {"height": l1_end, "blkid": _hex(l1_end, namespace=1)},
+            "txid": _hex(idx, namespace=3),
+            "wtxid": _hex(idx, namespace=4),
+        }
+
         # Older checkpoints are finalized; newest two are confirmed/pending
         if idx < self._n - 2:
-            status = "finalized"
+            conf_status = {"status": "finalized", "l1_reference": l1_ref}
         elif idx == self._n - 2:
-            status = "confirmed"
+            conf_status = {"status": "confirmed", "l1_reference": l1_ref}
         else:
-            status = "pending"
+            conf_status = {"status": "pending"}
 
         return {
             "idx": idx,
@@ -75,28 +81,27 @@ class _MockServer(HTTPServer):
                 {"slot": l2_start, "blkid": _hex(l2_start, namespace=2)},
                 {"slot": l2_end, "blkid": _hex(l2_end, namespace=2)},
             ],
-            "l1_reference": {
-                "block_height": l1_end,
-                "block_id": _hex(l1_end, namespace=1),
-                "txid": _hex(idx, namespace=3),
-                "wtxid": _hex(idx, namespace=4),
-            },
-            "confirmation_status": status,
+            "confirmation_status": conf_status,
         }
 
-    def _headers_at_idx(self, height: int):
-        prev = _hex(height - 1, namespace=2) if height > 0 else "0" * 64
-        return [
-            {
-                "block_idx": height,
+    def _headers_in_range(self, start: int, end: int):
+        headers = []
+        for height in range(start, end + 1):
+            epoch = height // self._bpc
+            prev = _hex(height - 1, namespace=2) if height > 0 else "0" * 64
+            is_terminal = (height % self._bpc) == (self._bpc - 1)
+            headers.append({
+                "slot": height,
+                "epoch": epoch,
+                "blkid": _hex(height, namespace=2),
                 "timestamp": 1_700_000_000 + height * 12,
-                "block_id": _hex(height, namespace=2),
-                "prev_block": prev,
-                "l1_segment_hash": _hex(height, namespace=5),
-                "exec_segment_hash": _hex(height, namespace=6),
+                "parent_blkid": prev,
                 "state_root": _hex(height, namespace=7),
-            }
-        ]
+                "body_root": _hex(height, namespace=5),
+                "logs_root": _hex(height, namespace=6),
+                "is_terminal": is_terminal,
+            })
+        return headers
 
 
 class MockFullnodeService:


### PR DESCRIPTION
# STR-2540: Update explorer to new Strata RPC interface

## Summary

Updates the checkpoint explorer backend to work with the revised Strata RPC interface and improves the block fetching algorithm.

### RPC interface changes

| Old | New |
|-----|-----|
| `strata_getLatestCheckpointIndex` | `strata_getChainStatus` → `confirmed.epoch` |
| `strata_getHeadersAtIdx(slot)` | `strata_getHeadersInRange(start, end)` |

- `RpcCheckpointInfo.confirmation_status` is now a tagged enum (`pending` / `confirmed { l1_reference }` / `finalized { l1_reference }`). 
- Added `RpcOLChainStatus` / `EpochCommitment` wire types for `strata_getChainStatus`.
- Replaced the generic `fetch_data<T>(method, idx)` helper with a dedicated `fetch_checkpoint_info(idx)` method.

### Block fetch algorithm

Previously the block fetcher received one mpsc message per checkpoint and made a separate RPC call per block slot.

The new algorithm:
1. A `watch` channel carries the L2 end slot of the latest checkpoint seen by the checkpoint fetcher (`L2BlockFetchTarget`).
2. The block fetcher wakes only when the target changes (`rx.changed()`).
3. On wake, it reads the last stored block height from the DB and resumes from `last + 1`.
4. It fetches in batches of up to 5000 slots via `strata_getHeadersInRange`, advancing a cursor until it reaches the target.

This reduces RPC calls from O(n) per slot to O(n/5000) and avoids redundant fetching on restart.

### Other changes

- `tokio::select!` on all task `JoinHandle`s in `main` and inside the status updater; any task exit calls `std::process::exit(1)` to bring down the whole process (TODO: replace with service framework in follow-up).
- Removed redundant `block_exists` pre-check before INSERT; the DB unique constraint on `block_hash`/`height` rejects duplicates (MariaDB error 1062), logged at `debug` instead of `error`.
- Updated the mock fullnode in functional tests to match the new RPC interface.


### Local tests
I have run/observed the explorer locally.