### PR TITLE
fix(checkpoints): discover checkpoints from latest OL epoch

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -627,7 +627,7 @@ dependencies = [
  "hex",
  "migration",
  "model",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "sea-orm",
  "serde",
@@ -734,6 +734,18 @@ dependencies = [
  "serde_json",
  "toml",
  "yaml-rust",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
 ]
 
 [[package]]
@@ -1207,6 +1219,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1373,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"
@@ -1733,6 +1760,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "int-enum"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366a1634cccc76b4cfd3e7580de9b605e4d93f1edac48d786c1f867c0def495"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.94",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,7 +2064,7 @@ name = "migration"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "rand",
+ "rand 0.8.5",
  "sea-orm-migration",
  "uuid",
 ]
@@ -2080,6 +2119,7 @@ dependencies = [
  "hex",
  "sea-orm",
  "serde",
+ "strata-identifiers",
 ]
 
 [[package]]
@@ -2141,7 +2181,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2552,6 +2592,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +2636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,8 +2654,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2604,7 +2675,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2613,7 +2694,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2726,7 +2825,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2785,7 +2884,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2812,7 +2911,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -3275,7 +3374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3468,7 +3567,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "rust_decimal",
  "serde",
@@ -3513,7 +3612,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -3565,6 +3664,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strata-identifiers"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+dependencies = [
+ "const-hex",
+ "hex",
+ "int-enum",
+ "serde",
+]
 
 [[package]]
 name = "stringprep"
@@ -4038,6 +4148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,7 +4233,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -4169,6 +4285,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasite"
@@ -4553,6 +4678,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "write16"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -33,3 +33,4 @@ sea-orm-migration = "0.9"
 config = "0.13"
 dotenvy = "0.15.7"
 jsonrpsee = { version = "0.26.0", features = ["http-client"] }
+strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23", default-features = false, features = ["serde"] }

--- a/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
@@ -38,15 +38,19 @@ async fn fetch_checkpoints(
     info!("Fetching checkpoints from fullnode...");
 
     let chain_status = fetcher.get_chain_status().await?;
-    let fn_chkpt = chain_status.confirmed.epoch;
+    let latest_checkpoint = chain_status.latest.epoch();
+    let confirmed_checkpoint = chain_status.confirmed.epoch();
+    let finalized_checkpoint = chain_status.finalized.epoch();
 
     let starting_checkpoint = get_starting_checkpoint_idx(database.clone()).await?;
     info!(
-        fullnode_latest = fn_chkpt,
+        fullnode_latest = latest_checkpoint,
+        fullnode_confirmed = confirmed_checkpoint,
+        fullnode_finalized = finalized_checkpoint,
         local_start = starting_checkpoint,
         "Checkpoint sync range"
     );
-    for idx in starting_checkpoint..=fn_chkpt {
+    for idx in starting_checkpoint..=latest_checkpoint {
         if !checkpoint_db.checkpoint_exists(idx).await {
             info!(idx, "Checkpoint not in db, fetching");
             if let Ok(checkpoint) = fetcher.fetch_checkpoint_info(idx).await {
@@ -55,9 +59,17 @@ async fn fetch_checkpoints(
         }
     }
 
-    // notify block fetcher with the l2_end of the latest confirmed checkpoint
-    if let Some(latest) = checkpoint_db.get_checkpoint_by_idx(fn_chkpt).await {
-        let _ = tx.send(latest.l2_range.1);
+    let block_fetch_checkpoint = match checkpoint_db.get_checkpoint_by_idx(latest_checkpoint).await
+    {
+        Some(checkpoint) => Some(checkpoint),
+        None => match checkpoint_db.get_latest_checkpoint_index().await {
+            Some(idx) => checkpoint_db.get_checkpoint_by_idx(idx).await,
+            None => None,
+        },
+    };
+
+    if let Some(checkpoint) = block_fetch_checkpoint {
+        let _ = tx.send(checkpoint.l2_range.1);
     }
 
     Ok(())

--- a/backend/model/Cargo.toml
+++ b/backend/model/Cargo.toml
@@ -11,3 +11,4 @@ sea-orm = { workspace = true }
 serde = { workspace = true }
 hex = { workspace = true }
 anyhow = { workspace = true }
+strata-identifiers = { workspace = true }

--- a/backend/model/src/checkpoint.rs
+++ b/backend/model/src/checkpoint.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::result::Result;
 use std::str::FromStr;
+use strata_identifiers::EpochCommitment;
 /// Represents an L2 Block ID.
 pub type L2BlockId = String;
 pub type L1BlockId = String;
@@ -58,12 +59,9 @@ pub struct L2BlockCommitment {
 /// Wire type for strata_getChainStatus (only fields we use).
 #[derive(Debug, Deserialize)]
 pub struct RpcOLChainStatus {
+    pub latest: EpochCommitment,
     pub confirmed: EpochCommitment,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct EpochCommitment {
-    pub epoch: u32,
+    pub finalized: EpochCommitment,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, EnumIter, DeriveActiveEnum)]

--- a/functional-tests/envs/services/mock_fullnode.py
+++ b/functional-tests/envs/services/mock_fullnode.py
@@ -12,6 +12,15 @@ def _hex(seed: int, namespace: int = 0) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _epoch_commitment(epoch: int, blocks_per_checkpoint: int):
+    last_slot = (epoch + 1) * blocks_per_checkpoint - 1
+    return {
+        "epoch": epoch,
+        "last_slot": last_slot,
+        "last_blkid": _hex(last_slot, namespace=2),
+    }
+
+
 class _Handler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         pass  # suppress per-request logs
@@ -41,7 +50,14 @@ class _MockServer(HTTPServer):
 
     def dispatch(self, method: str, params: list):
         if method == "strata_getChainStatus":
-            return {"confirmed": {"epoch": self._n - 1}}
+            latest = max(0, self._n - 1)
+            confirmed = max(0, latest - 1)
+            finalized = max(0, confirmed - 1)
+            return {
+                "latest": _epoch_commitment(latest, self._bpc),
+                "confirmed": _epoch_commitment(confirmed, self._bpc),
+                "finalized": _epoch_commitment(finalized, self._bpc),
+            }
         if method == "strata_getCheckpointInfo":
             return self._checkpoint_info(int(params[0]))
         if method == "strata_getHeadersInRange":


### PR DESCRIPTION
## Discover checkpoints from the latest OL epoch

### Problem
The explorer gated checkpoint discovery on `strata_getChainStatus().confirmed.epoch`, fetching only `start..=confirmed`. A checkpoint sealed on the OL but not yet L1-confirmed (`latest > confirmed`) was never fetched, so it stayed invisible in the explorer until `confirmed` caught up — the observed checkpoint lag (`fullnode_latest=2` while checkpoint 3 was already sealed). Ref: [STR-3652](https://alpenlabs.atlassian.net/browse/STR-3652)

### Fix
- Discover checkpoints up to `latest.epoch` instead of `confirmed.epoch`; keep `confirmation_status` from `getCheckpointInfo` as the source of truth for display status.
- Deserialize `latest`, `confirmed`, and `finalized` from `getChainStatus` using `strata_identifiers::EpochCommitment`, pinned to the same `strata-common` tag used by `../alpen`.
- Require the full chain-status shape; no fallback to `confirmed` if `latest` is absent.
- Point the block fetcher at the latest checkpoint we attempted to sync, falling back to the highest checkpoint actually in the DB when the latest checkpoint is not stored yet.
- Log `fullnode_latest`, `fullnode_confirmed`, and `fullnode_finalized`.

### Testing
- `mock_fullnode` now returns full epoch commitments for all three slots (`latest = n−1` reported as Pending), exercising the pending-checkpoint discovery path.

### Note / follow-up
Deserialization is now strict: each epoch slot requires `epoch` + `last_slot` + `last_blkid`. Confirm the live `strata_getChainStatus` returns full `EpochCommitment` objects before relying on this in production.

[STR-3652]: https://alpenlabs.atlassian.net/browse/STR-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ