### PR TITLE
cd: push to shared-services ECR, drop environment

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,16 +10,6 @@ on:
   #   types:
   #     - closed
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Select environment'
-        required: true
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          # currently we do not support cd to production, its only for future reference
-          - production
 env:
   CI: false
   COMMIT: ${{ github.sha }}
@@ -33,13 +23,9 @@ jobs:
     # if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     name: Detect Changes
     runs-on: ubuntu-latest
-    env:
-      # select environment based on branch or manual input
-      ENVIRONMENT: ${{ inputs.environment || (github.ref == 'refs/heads/main' && 'staging') }}
     outputs:
       frontend_changed: ${{ steps.filter.outputs.frontend }}
       backend_changed: ${{ steps.filter.outputs.backend }}
-      environment: ${{ env.ENVIRONMENT }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,7 +54,6 @@ jobs:
     name: Build and Push Docker Images
     runs-on: ubuntu-latest
     needs: detect-changes
-    environment: ${{ needs.detect-changes.outputs.environment }}
     strategy:
       matrix:
         service: [frontend, backend]
@@ -100,7 +85,9 @@ jobs:
 
           DOCKERFILE_PATH="$SERVICE/Dockerfile"
           CONTEXT_DIR="$SERVICE"
-          ECR_REPOSITORY="$ECR_REPOSITORY_PREFIX/${SERVICE}"
+          # Shared-services repos are hyphen-named: strata/batch-exp-{backend,frontend}.
+          # Set repo var ECR_REPOSITORY_PREFIX=strata/batch-exp.
+          ECR_REPOSITORY="${ECR_REPOSITORY_PREFIX}-${SERVICE}"
 
           # Build with both tags
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \


### PR DESCRIPTION
Simplifies the build/push workflow to a single CI flow and points it at the shared-services ECR.

## Changes (`.github/workflows/cd.yaml`)
- **Drop environment usage** (per "no need environment, we just have ci"): removed the `workflow_dispatch` environment input, the `detect-changes` `ENVIRONMENT` env + `environment` output, and the `build-and-push` `environment:` key.
- **Shared-services repo path:** build `ECR_REPOSITORY` as `\${ECR_REPOSITORY_PREFIX}-\${SERVICE}` (hyphen) so it targets `strata/batch-exp-backend` / `strata/batch-exp-frontend` — the previous `\$PREFIX/\${SERVICE}` (slash) produced `…/batch-exp/frontend`, which doesn't exist in shared-services.

## Required repo settings (coordinated with this change)
- Variable `ECR_REPOSITORY_PREFIX` = `strata/batch-exp`
- Secret `AWS_ECR_ROLE` = `arn:aws:iam::496607027995:role/github-actions-checkpoint-explorer-push` (the dedicated least-privilege role, scoped to those two repos)

With both set, CI builds push directly to shared-services and the manual master→shared mirror is no longer needed.

## Note
Actions are still tag-pinned (`@v4`/`@v2`/`@v3`); SHA-pinning can be a follow-up per CI hardening standards.