### PR TITLE
STR 2946 Parallelize block fetching within checkpoints

### DIFF
--- a/backend/bin/checkpoint-explorer/src/services/block_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/block_service.rs
@@ -1,12 +1,50 @@
 use database::connection::DatabaseWrapper;
 use database::services::block_service::BlockService;
 use fullnode_client::fetcher::StrataFetcher;
+use model::block::RpcBlockHeader;
 use model::checkpoint::L2BlockFetchTarget;
 use std::sync::Arc;
 use tokio::sync::watch::Receiver;
-use tracing::{error, info};
+use tokio::task::JoinSet;
+use tracing::{debug, error, info, warn};
 
 const MAX_HEADERS_RANGE: u64 = 5000;
+const BLOCK_FETCH_CONCURRENCY: usize = 20;
+
+/// Inclusive block header range requested from the fullnode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct HeaderRange {
+    start: u64,
+    end: u64,
+}
+
+/// Headers returned for one requested range.
+#[derive(Debug)]
+struct FetchedHeaderChunk {
+    range: HeaderRange,
+    headers: Vec<RpcBlockHeader>,
+}
+
+/// Requested range that failed before returning headers.
+#[derive(Debug)]
+struct FailedHeaderChunk {
+    range: HeaderRange,
+}
+
+/// Result of fetching block header ranges.
+#[derive(Debug)]
+struct HeaderFetchReport {
+    fetched: Vec<FetchedHeaderChunk>,
+    failed: Vec<FailedHeaderChunk>,
+    task_failures: usize,
+}
+
+impl HeaderFetchReport {
+    /// Number of failed range requests or failed fetch tasks in this report.
+    fn failure_count(&self) -> usize {
+        self.failed.len() + self.task_failures
+    }
+}
 
 pub async fn run_block_fetcher(
     fetcher: Arc<StrataFetcher>,
@@ -36,22 +74,284 @@ async fn fetch_blocks(fetcher: Arc<StrataFetcher>, database: Arc<DatabaseWrapper
         return;
     }
 
+    let ranges = build_block_fetch_ranges(start, target);
+    info!(
+        start,
+        target,
+        chunks = ranges.len(),
+        concurrency = BLOCK_FETCH_CONCURRENCY,
+        "Fetching blocks"
+    );
+
     let mut cursor = start;
-    info!(cursor, target, "Fetching blocks");
-    while cursor <= target {
-        let chunk_end = (cursor + MAX_HEADERS_RANGE - 1).min(target);
-        match fetcher.fetch_headers_in_range(cursor, chunk_end).await {
-            Ok(headers) => {
-                for header in headers {
-                    let checkpoint_idx = header.epoch;
-                    block_db.insert_block(header, checkpoint_idx).await;
-                }
-                cursor = chunk_end + 1;
+    for wave in ranges.chunks(BLOCK_FETCH_CONCURRENCY) {
+        let wave_end = wave.last().map(|range| range.end).unwrap_or(cursor);
+        let fetch_report = fetch_header_wave(fetcher.clone(), wave).await;
+        let failed_chunks = fetch_report.failure_count();
+        let failed_ranges: Vec<_> = fetch_report
+            .failed
+            .iter()
+            .map(|chunk| chunk.range)
+            .collect();
+
+        let mut insertable_headers = collect_insertable_headers(fetch_report.fetched, cursor);
+        let insertable_header_count = insertable_headers.len();
+
+        if insertable_headers.is_empty() {
+            warn!(
+                cursor,
+                wave_end,
+                failed_chunks,
+                ?failed_ranges,
+                "No insertable block headers fetched"
+            );
+            return;
+        }
+
+        let last_insertable_slot = insertable_headers
+            .last()
+            .map(|header| header.slot)
+            .unwrap_or(cursor);
+        debug!(
+            cursor,
+            wave_end,
+            last_insertable_slot,
+            insertable_header_count,
+            failed_chunks,
+            "Fetched insertable block headers"
+        );
+
+        for header in insertable_headers.drain(..) {
+            let checkpoint_idx = header.epoch;
+            block_db.insert_block(header, checkpoint_idx).await;
+        }
+
+        if failed_chunks > 0 || last_insertable_slot < wave_end {
+            info!(
+                next_start = last_insertable_slot + 1,
+                target,
+                failed_chunks,
+                ?failed_ranges,
+                "Stopping block fetch after partial progress"
+            );
+            return;
+        }
+
+        cursor = last_insertable_slot + 1;
+    }
+}
+
+/// Fetches one bounded wave of ranges concurrently and returns all successful headers.
+async fn fetch_header_wave(
+    fetcher: Arc<StrataFetcher>,
+    ranges: &[HeaderRange],
+) -> HeaderFetchReport {
+    let mut tasks = JoinSet::new();
+
+    for &range in ranges {
+        let fetcher = fetcher.clone();
+        tasks.spawn(async move {
+            fetcher
+                .fetch_headers_in_range(range.start, range.end)
+                .await
+                .map(|headers| FetchedHeaderChunk { range, headers })
+                .map_err(|err| (range, err))
+        });
+    }
+
+    let mut fetched = Vec::new();
+    let mut failed = Vec::new();
+    let mut task_failures = 0;
+
+    while let Some(result) = tasks.join_next().await {
+        match result {
+            Ok(Ok(chunk)) => {
+                debug!(
+                    start = chunk.range.start,
+                    end = chunk.range.end,
+                    headers = chunk.headers.len(),
+                    "Fetched block header chunk"
+                );
+                fetched.push(chunk);
             }
-            Err(e) => {
-                error!(?e, cursor, chunk_end, "Failed to fetch block headers");
-                return;
+            Ok(Err((range, err))) => {
+                error!(
+                    ?err,
+                    start = range.start,
+                    end = range.end,
+                    "Failed to fetch block headers"
+                );
+                failed.push(FailedHeaderChunk { range });
+            }
+            Err(err) => {
+                task_failures += 1;
+                error!(?err, "Block header fetch task failed");
             }
         }
+    }
+
+    HeaderFetchReport {
+        fetched,
+        failed,
+        task_failures,
+    }
+}
+
+/// Splits an inclusive block range into non-overlapping RPC ranges.
+fn build_block_fetch_ranges(start: u64, target: u64) -> Vec<HeaderRange> {
+    let mut ranges = Vec::new();
+    let mut cursor = start;
+
+    while cursor <= target {
+        let end = (cursor + MAX_HEADERS_RANGE - 1).min(target);
+        ranges.push(HeaderRange { start: cursor, end });
+        cursor = end + 1;
+    }
+
+    ranges
+}
+
+/// Collects headers from adjacent chunks beginning at start.
+fn collect_insertable_headers(
+    mut chunks: Vec<FetchedHeaderChunk>,
+    start: u64,
+) -> Vec<RpcBlockHeader> {
+    chunks.sort_by_key(|chunk| chunk.range);
+
+    let mut expected_slot = start;
+    let mut insertable_headers = Vec::new();
+
+    for mut chunk in chunks {
+        if chunk.range.start != expected_slot {
+            break;
+        }
+
+        let Some(first_header) = chunk.headers.first() else {
+            break;
+        };
+
+        if first_header.slot != expected_slot {
+            break;
+        }
+
+        let last_header_slot = chunk
+            .headers
+            .last()
+            .map(|header| header.slot)
+            .unwrap_or(expected_slot);
+
+        if last_header_slot > chunk.range.end {
+            break;
+        }
+
+        insertable_headers.append(&mut chunk.headers);
+
+        if last_header_slot < chunk.range.end {
+            break;
+        }
+
+        expected_slot = last_header_slot + 1;
+    }
+
+    insertable_headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header(slot: u64) -> RpcBlockHeader {
+        RpcBlockHeader {
+            slot,
+            epoch: 0,
+            blkid: format!("{slot:064x}"),
+            timestamp: 0,
+            parent_blkid: format!("{:064x}", slot.saturating_sub(1)),
+            state_root: format!("{slot:064x}"),
+            body_root: format!("{slot:064x}"),
+            logs_root: format!("{slot:064x}"),
+            is_terminal: false,
+        }
+    }
+
+    #[test]
+    fn creates_singleton_range() {
+        assert_eq!(build_block_fetch_ranges(0, 0), vec![range(0, 0)]);
+    }
+
+    #[test]
+    fn creates_single_range_below_limit() {
+        assert_eq!(build_block_fetch_ranges(10, 20), vec![range(10, 20)]);
+    }
+
+    #[test]
+    fn splits_range_above_limit() {
+        assert_eq!(
+            build_block_fetch_ranges(0, MAX_HEADERS_RANGE),
+            vec![
+                range(0, MAX_HEADERS_RANGE - 1),
+                range(MAX_HEADERS_RANGE, MAX_HEADERS_RANGE)
+            ]
+        );
+    }
+
+    fn range(start: u64, end: u64) -> HeaderRange {
+        HeaderRange { start, end }
+    }
+
+    fn chunk(start: u64, end: u64, slots: &[u64]) -> FetchedHeaderChunk {
+        FetchedHeaderChunk {
+            range: range(start, end),
+            headers: slots.iter().map(|slot| header(*slot)).collect(),
+        }
+    }
+
+    fn slots(headers: Vec<RpcBlockHeader>) -> Vec<u64> {
+        headers.into_iter().map(|header| header.slot).collect()
+    }
+
+    #[test]
+    fn collects_insertable_headers_from_adjacent_chunks() {
+        let insertable_headers =
+            collect_insertable_headers(vec![chunk(5, 6, &[5, 6]), chunk(7, 8, &[7, 8])], 5);
+
+        assert_eq!(slots(insertable_headers), vec![5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn collects_insertable_headers_from_chunks_completed_out_of_order() {
+        let insertable_headers =
+            collect_insertable_headers(vec![chunk(7, 8, &[7, 8]), chunk(5, 6, &[5, 6])], 5);
+
+        assert_eq!(slots(insertable_headers), vec![5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn stops_before_missing_chunk() {
+        let insertable_headers =
+            collect_insertable_headers(vec![chunk(5, 6, &[5, 6]), chunk(9, 10, &[9, 10])], 5);
+
+        assert_eq!(slots(insertable_headers), vec![5, 6]);
+    }
+
+    #[test]
+    fn returns_empty_when_starting_chunk_is_missing() {
+        let insertable_headers = collect_insertable_headers(vec![chunk(6, 7, &[6, 7])], 5);
+
+        assert!(insertable_headers.is_empty());
+    }
+
+    #[test]
+    fn preserves_short_read_insertable_headers() {
+        let insertable_headers = collect_insertable_headers(vec![chunk(5, 9, &[5, 6, 7])], 5);
+
+        assert_eq!(slots(insertable_headers), vec![5, 6, 7]);
+    }
+
+    #[test]
+    fn returns_empty_when_chunk_headers_do_not_start_at_cursor() {
+        let insertable_headers = collect_insertable_headers(vec![chunk(5, 7, &[6, 7])], 5);
+
+        assert!(insertable_headers.is_empty());
     }
 }

--- a/functional-tests/entry.py
+++ b/functional-tests/entry.py
@@ -39,7 +39,18 @@ def main(argv):
 
     flexitest.runtime.load_candidate_modules(modules)
 
-    global_envs = {"explorer": ExplorerEnvConfig()}
+    global_envs = {
+        "explorer": ExplorerEnvConfig(),
+        "explorer_parallel_blocks": ExplorerEnvConfig(
+            # Coupled to backend MAX_HEADERS_RANGE=5000: 10002 blocks create 3 chunks.
+            num_checkpoints=2,
+            blocks_per_checkpoint=5001,
+            fullnode_port=18001,
+            db_port=13307,
+            backend_port=13001,
+            header_response_delay=0.2,
+        ),
+    }
 
     datadir_root = flexitest.create_datadir_in_workspace(os.path.join(root_dir, DD_ROOT))
     rt = flexitest.TestRuntime(global_envs, datadir_root, {})

--- a/functional-tests/envs/services/mock_fullnode.py
+++ b/functional-tests/envs/services/mock_fullnode.py
@@ -3,7 +3,8 @@
 import hashlib
 import json
 import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
 def _hex(seed: int, namespace: int = 0) -> str:
@@ -42,11 +43,24 @@ class _Handler(BaseHTTPRequestHandler):
         self.wfile.write(resp_bytes)
 
 
-class _MockServer(HTTPServer):
-    def __init__(self, host: str, port: int, num_checkpoints: int, blocks_per_checkpoint: int):
+class _MockServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        num_checkpoints: int,
+        blocks_per_checkpoint: int,
+        header_response_delay: float,
+    ):
         super().__init__((host, port), _Handler)
         self._n = num_checkpoints
         self._bpc = blocks_per_checkpoint
+        self._header_response_delay = header_response_delay
+        self._header_request_lock = threading.Lock()
+        self._active_header_requests = 0
+        self._max_concurrent_header_requests = 0
 
     def dispatch(self, method: str, params: list):
         if method == "strata_getChainStatus":
@@ -61,8 +75,12 @@ class _MockServer(HTTPServer):
         if method == "strata_getCheckpointInfo":
             return self._checkpoint_info(int(params[0]))
         if method == "strata_getHeadersInRange":
-            return self._headers_in_range(int(params[0]), int(params[1]))
+            return self._tracked_headers_in_range(int(params[0]), int(params[1]))
         return None
+
+    def max_concurrent_header_requests(self):
+        with self._header_request_lock:
+            return self._max_concurrent_header_requests
 
     def _checkpoint_info(self, idx: int):
         if idx < 0 or idx >= self._n:
@@ -119,6 +137,22 @@ class _MockServer(HTTPServer):
             })
         return headers
 
+    def _tracked_headers_in_range(self, start: int, end: int):
+        with self._header_request_lock:
+            self._active_header_requests += 1
+            self._max_concurrent_header_requests = max(
+                self._max_concurrent_header_requests,
+                self._active_header_requests,
+            )
+
+        try:
+            if self._header_response_delay > 0:
+                time.sleep(self._header_response_delay)
+            return self._headers_in_range(start, end)
+        finally:
+            with self._header_request_lock:
+                self._active_header_requests -= 1
+
 
 class MockFullnodeService:
     """
@@ -131,10 +165,22 @@ class MockFullnodeService:
     - Status: finalized (old), confirmed (second-to-last), pending (latest)
     """
 
-    def __init__(self, port: int, num_checkpoints: int = 5, blocks_per_checkpoint: int = 10):
+    def __init__(
+        self,
+        port: int,
+        num_checkpoints: int = 5,
+        blocks_per_checkpoint: int = 10,
+        header_response_delay: float = 0.0,
+    ):
         self.port = port
         self.url = f"http://127.0.0.1:{port}/"
-        self._server = _MockServer("127.0.0.1", port, num_checkpoints, blocks_per_checkpoint)
+        self._server = _MockServer(
+            "127.0.0.1",
+            port,
+            num_checkpoints,
+            blocks_per_checkpoint,
+            header_response_delay,
+        )
         self._thread: threading.Thread | None = None
         self.num_checkpoints = num_checkpoints
         self.blocks_per_checkpoint = blocks_per_checkpoint
@@ -147,3 +193,9 @@ class MockFullnodeService:
         self._server.shutdown()
         if self._thread:
             self._thread.join(timeout=5)
+
+    def max_concurrent_header_requests(self):
+        return self._server.max_concurrent_header_requests()
+
+    def block_hash(self, height: int):
+        return _hex(height, namespace=2)

--- a/functional-tests/envs/testenv.py
+++ b/functional-tests/envs/testenv.py
@@ -40,6 +40,9 @@ class ExplorerLiveEnv(flexitest.LiveEnv):
     def get_explorer_client(self) -> ExplorerApiClient:
         return self._client
 
+    def get_fullnode(self) -> MockFullnodeService:
+        return self._fullnode
+
     def shutdown(self):
         self._backend.stop()
         self._database.stop()
@@ -60,25 +63,34 @@ class ExplorerEnvConfig(flexitest.EnvConfig):
         self,
         num_checkpoints: int = _NUM_CHECKPOINTS,
         blocks_per_checkpoint: int = _BLOCKS_PER_CHECKPOINT,
+        fullnode_port: int = _FULLNODE_PORT,
+        db_port: int = _DB_PORT,
+        backend_port: int = _BACKEND_PORT,
+        header_response_delay: float = 0.0,
     ):
         super().__init__()
         self.num_checkpoints = num_checkpoints
         self.blocks_per_checkpoint = blocks_per_checkpoint
+        self.fullnode_port = fullnode_port
+        self.db_port = db_port
+        self.backend_port = backend_port
+        self.header_response_delay = header_response_delay
 
     def init(self, ectx: flexitest.EnvContext) -> ExplorerLiveEnv:
         fullnode = MockFullnodeService(
-            port=_FULLNODE_PORT,
+            port=self.fullnode_port,
             num_checkpoints=self.num_checkpoints,
             blocks_per_checkpoint=self.blocks_per_checkpoint,
+            header_response_delay=self.header_response_delay,
         )
         fullnode.start()
 
-        database = DatabaseService(port=_DB_PORT)
+        database = DatabaseService(port=self.db_port)
         database.start()
 
         datadir = ectx.make_service_dir("backend")
         backend = BackendService(
-            port=_BACKEND_PORT,
+            port=self.backend_port,
             fullnode_url=fullnode.url,
             database_url=database.url,
             log_file=os.path.join(datadir, "service.log"),
@@ -105,6 +117,10 @@ class ExplorerTestBase(flexitest.Test):
     def get_client(self, ctx: flexitest.RunContext) -> ExplorerApiClient:
         env: ExplorerLiveEnv = ctx.env
         return env.get_explorer_client()
+
+    def get_fullnode(self, ctx: flexitest.RunContext) -> MockFullnodeService:
+        env: ExplorerLiveEnv = ctx.env
+        return env.get_fullnode()
 
 
 def _synced_count(client: ExplorerApiClient) -> int:

--- a/functional-tests/tests/parallel_block_fetch.py
+++ b/functional-tests/tests/parallel_block_fetch.py
@@ -1,0 +1,41 @@
+import flexitest
+
+from envs import testenv
+from utils.wait import wait_until
+
+EXPECTED_HEADER_CHUNKS = 3
+
+
+@flexitest.register
+class ParallelBlockFetchConcurrencyTest(testenv.ExplorerTestBase):
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env("explorer_parallel_blocks")
+
+    def main(self, ctx: flexitest.RunContext):
+        client = self.get_client(ctx)
+        fullnode = self.get_fullnode(ctx)
+
+        # 10002 blocks / backend MAX_HEADERS_RANGE=5000 gives 3 chunks in one wave.
+        wait_until(
+            lambda: fullnode.max_concurrent_header_requests() >= EXPECTED_HEADER_CHUNKS,
+            error_with="Block header range requests did not fan out to all chunks",
+            timeout=30,
+            step=0.1,
+        )
+
+        latest_slot = fullnode.num_checkpoints * fullnode.blocks_per_checkpoint - 1
+        # insert_block requires predecessors, so indexing the latest slot proves continuity.
+        wait_until(
+            lambda: "result" in client.search(str(latest_slot)),
+            error_with=f"Latest block {latest_slot} was not indexed",
+            timeout=60,
+            step=0.5,
+        )
+        wait_until(
+            lambda: "result" in client.search(fullnode.block_hash(latest_slot)),
+            error_with=f"Latest block hash for slot {latest_slot} was not indexed",
+            timeout=60,
+            step=0.5,
+        )
+
+        return True


### PR DESCRIPTION
## Summary

Parallelize OL block-header fetching while preserving ordered, gap-free DB insertion.

Previously the block fetcher awaited each `strata_getHeadersInRange` chunk sequentially. This fans chunks out concurrently (up to 20 in flight), then inserts only headers from adjacent fetched chunks starting at the next expected local height. Failed or incomplete waves persist safe progress and resume from the new DB height on the next cycle.

## What changed

- **Concurrent fetch in bounded waves.** Missing range -> 5000-slot chunks -> up to `BLOCK_FETCH_CONCURRENCY = 20` fetched in parallel via `tokio::task::JoinSet` (no new dependency).
- **Range-aware chunk processing.** Fetch results preserve `HeaderRange` metadata in `FetchedHeaderChunk` / `HeaderFetchReport`, so the inserter checks chunk boundaries instead of sorting every returned header.
- **Insertable-header insertion.** The fetcher collects `insertable_headers` from adjacent chunks starting at the current DB cursor, then inserts them sequentially. A failed chunk or short read inserts what's safe and resumes later.
- **DB insertion stays sequential.** `BlockService::insert_block` remains the final continuity guard. This change only parallelizes network I/O; no API or schema changes.

## Testing

- **Unit tests** for `build_block_fetch_ranges` and `collect_insertable_headers` covering chunking, out-of-order chunk completion, missing chunks, short reads, and missing cursor starts.
- **Functional test** (`parallel_block_fetch.py`): mock fullnode uses `ThreadingHTTPServer` with a per-request concurrency counter. Asserts (a) header requests fan out to all 3 chunks concurrently, and (b) the latest block is indexed by both height and hash.

## Notes

- Concurrency limit and `MAX_HEADERS_RANGE` are constants for now; they can be moved to config if production tuning needs it.
- Waves run sequentially: fetch wave N, insert safe headers from that wave, then fetch wave N+1.