### PR TITLE
fix(functional-tests): move flexitest to dev dependency

### DIFF
--- a/functional-tests/pyproject.toml
+++ b/functional-tests/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 description = "Functional tests for the checkpoint explorer API"
 authors = []
 requires-python = ">=3.10"
-dependencies = [
-  "flexitest",
+dependencies = []
+
+[dependency-groups]
+dev = [
+  "flexitest @ git+https://codeberg.org/treyd/flexitest.git@50841c19444e154eb18750cade4cd89587c24344",
   "requests>=2.32,<3",
 ]
-
-[tool.uv.sources]
-flexitest = { git = "https://codeberg.org/treyd/flexitest.git" }
 
 [build-system]
 requires = ["hatchling"]

--- a/functional-tests/uv.lock
+++ b/functional-tests/uv.lock
@@ -120,21 +120,25 @@ wheels = [
 name = "checkpoint-explorer-functional-tests"
 version = "0.1.0"
 source = { editable = "." }
-dependencies = [
+
+[package.dev-dependencies]
+dev = [
     { name = "flexitest" },
     { name = "requests" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "flexitest", git = "https://codeberg.org/treyd/flexitest.git" },
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "flexitest", git = "https://codeberg.org/treyd/flexitest.git?rev=50841c19444e154eb18750cade4cd89587c24344" },
     { name = "requests", specifier = ">=2.32,<3" },
 ]
 
 [[package]]
 name = "flexitest"
 version = "0.1.0"
-source = { git = "https://codeberg.org/treyd/flexitest.git#3f1346143922bdcdccb3ad64298db80825e6ae93" }
+source = { git = "https://codeberg.org/treyd/flexitest.git?rev=50841c19444e154eb18750cade4cd89587c24344#50841c19444e154eb18750cade4cd89587c24344" }
 
 [[package]]
 name = "idna"


### PR DESCRIPTION
## Summary
- move functional-test dependencies out of package runtime dependencies and into the dev dependency group
- pin flexitest as a standards-visible direct git dependency to the same Codeberg commit used by alpenlabs/alpen
- refresh uv.lock so flexitest is resolved as a dev dependency rather than a runtime requirement

## Verification
- uv lock --check
- uv sync --locked --dry-run