### PR TITLE
ci: run required checks for merge queue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   functional-tests:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 jobs:
   rust:


### PR DESCRIPTION
## Summary
- run CI and lint workflows for GitHub merge queue commits via the merge_group event
- ensures required checks are created for merge queue entries, not only pull_request commits

## Context
PR #70 was repeatedly kicked out of the merge queue because required checks need to run on merge_group refs as well as pull_request refs.

## Verification
- inspected workflow YAML locally
- no runtime code changes