### PR TITLE
STR 3949 refetch pending checkpoints through latest epoch

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3697,7 +3697,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "const-hex",
  "hex",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -33,4 +33,4 @@ sea-orm-migration = "0.9"
 config = "0.13"
 dotenvy = "0.15.7"
 jsonrpsee = { version = "0.26.0", features = ["http-client"] }
-strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23", default-features = false, features = ["serde"] }
+strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.2", default-features = false, features = ["serde"] }

--- a/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
@@ -187,10 +187,10 @@ async fn update_checkpoints_status(
     let checkpoint_db = CheckpointService::new(&database.db);
     let chain_status = fetcher.get_chain_status().await?;
     // Highest checkpoint index that can have transitioned out of this local status.
-    // Pending checkpoints can become confirmed/finalized through the confirmed boundary;
+    // Pending checkpoints can become confirmed as soon as `strata_getCheckpointInfo` sees an L1 ref;
     // confirmed checkpoints can become finalized through the finalized boundary.
     let transition_boundary_idx = match status {
-        RpcCheckpointConfStatus::Pending => chain_status.confirmed.epoch(),
+        RpcCheckpointConfStatus::Pending => chain_status.latest.epoch(),
         RpcCheckpointConfStatus::Confirmed => chain_status.finalized.epoch(),
         RpcCheckpointConfStatus::Finalized => return Ok(()),
     };

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -24,8 +24,9 @@ services:
     container_name: checkpoint_explorer_app
     environment:
       APP_DATABASE_URL: mysql://explorer:password@mariadb:3306/checkpoint_explorer_db
-      STRATA_FULLNODE: "https://rpc.testnet-staging.stratabtc.org/"
+      STRATA_FULLNODE: "http://host.docker.internal:8432"
       APP_FETCH_INTERVAL: 5
+      APP_STATUS_UPDATE_INTERVAL: 5
     ports:
       - "3000:3000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       APP_DATABASE_URL: mysql://explorer:password@mariadb:3306/checkpoint_explorer_db
       STRATA_FULLNODE: "http://host.docker.internal:8432"
       APP_FETCH_INTERVAL: 5
+      APP_STATUS_UPDATE_INTERVAL: 5
       RUST_LOG: "info,sqlx::query=warn"
     ports:
       - "3000:3000"

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,7 +1,7 @@
 {
   "apiBaseUrl": "http://localhost:3000",
-  "bitcoinExplorerBaseUrl": "https://bitcoin.testnet-staging.stratabtc.org",
-  "alpenExplorerBaseUrl": "https://explorer.testnet-staging.stratabtc.org",
+  "bitcoinExplorerBaseUrl": "https://bitcoin-staging.testnet-v2.alpenlabs.io",
+  "alpenExplorerBaseUrl": "https://explorer-staging.testnet-v2.alpenlabs.io",
   "refreshIntervalS": 120,
   "environment": "staging"
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
   },
   server: {
     allowedHosts: [
-      "checkpoints.testnet.alpenlabs.io",
-      "checkpoints.testnet-staging.stratabtc.org",
+      "checkpoints.testnet.alpen.org",
+      "checkpoints-staging.testnet-v2.alpenlabs.io",
     ],
   },
 });


### PR DESCRIPTION
## Summary

Fixes checkpoint status updates so pending checkpoints are refetched through the latest completed epoch instead of the lagging confirmed epoch.

This lets the explorer observe `strata_getCheckpointInfo(N) -> Confirmed` as soon as the fullnode reports the L1 reference, without waiting for `getChainStatus.confirmed.epoch()` to advance.

## Changes

- Use `chain_status.latest.epoch()` as the pending checkpoint status-update boundary.
- Keep confirmed-to-finalized updates bounded by `chain_status.finalized.epoch()`.
- Align Docker compose status update interval config.
- Update staging explorer URLs and `strata-identifiers` to `strata-common` `v0.3.0-rc.2`.

## Testing
Tested in docker env