### PR TITLE
STR 3876 Update the `strata_getCheckpointInfo` response handler to match the updated response

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3697,7 +3697,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.2#c3698c0f26d8d3d16e56a478eb375e077d813775"
 dependencies = [
  "const-hex",
  "hex",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3697,7 +3697,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "const-hex",
  "hex",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -33,4 +33,4 @@ sea-orm-migration = "0.9"
 config = "0.13"
 dotenvy = "0.15.7"
 jsonrpsee = { version = "0.26.0", features = ["http-client"] }
-strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23", default-features = false, features = ["serde"] }
+strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.2", default-features = false, features = ["serde"] }

--- a/backend/bin/checkpoint-explorer/src/services/block_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/block_service.rs
@@ -262,17 +262,18 @@ mod tests {
     use super::*;
 
     fn header(slot: u64) -> RpcBlockHeader {
-        RpcBlockHeader {
-            slot,
-            epoch: 0,
-            blkid: format!("{slot:064x}"),
-            timestamp: 0,
-            parent_blkid: format!("{:064x}", slot.saturating_sub(1)),
-            state_root: format!("{slot:064x}"),
-            body_root: format!("{slot:064x}"),
-            logs_root: format!("{slot:064x}"),
-            is_terminal: false,
-        }
+        serde_json::from_value(serde_json::json!({
+            "slot": slot,
+            "epoch": 0,
+            "blkid": format!("{slot:064x}"),
+            "timestamp": 0,
+            "parent_blkid": format!("{:064x}", slot.saturating_sub(1)),
+            "state_root": format!("{slot:064x}"),
+            "body_root": format!("{slot:064x}"),
+            "logs_root": format!("{slot:064x}"),
+            "is_terminal": false,
+        }))
+        .expect("test block header should deserialize")
     }
 
     #[test]

--- a/backend/bin/checkpoint-explorer/src/services/block_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/block_service.rs
@@ -123,7 +123,7 @@ async fn fetch_blocks(fetcher: Arc<StrataFetcher>, database: Arc<DatabaseWrapper
         );
 
         for header in insertable_headers.drain(..) {
-            let checkpoint_idx = header.epoch;
+            let checkpoint_idx = u64::from(header.epoch);
             block_db.insert_block(header, checkpoint_idx).await;
         }
 

--- a/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
@@ -246,10 +246,12 @@ async fn update_checkpoints_status(
         let current_txid = checkpoint_in_db
             .l1_reference
             .as_ref()
-            .map(|l1_ref| &l1_ref.txid);
+            .map(|l1_ref| l1_ref.txid.as_str());
 
         // This checkpoint is already current, but later rows in the bounded range may have changed.
-        if checkpoint_in_db.confirmation_status == Some(new_status) && current_txid == new_txid {
+        if checkpoint_in_db.confirmation_status == Some(new_status)
+            && current_txid == new_txid.as_deref()
+        {
             idx = idx.saturating_add(1);
             continue;
         }

--- a/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
+++ b/backend/bin/checkpoint-explorer/src/services/checkpoint_service.rs
@@ -51,7 +51,7 @@ async fn fetch_checkpoints(
         "Checkpoint sync range"
     );
     for idx in starting_checkpoint..=latest_checkpoint {
-        if !checkpoint_db.checkpoint_exists(idx).await {
+        if !checkpoint_db.checkpoint_exists(u64::from(idx)).await {
             info!(idx, "Checkpoint not in db, fetching");
             if let Ok(checkpoint) = fetcher.fetch_checkpoint_info(idx).await {
                 checkpoint_db.insert_checkpoint(checkpoint).await;
@@ -59,7 +59,9 @@ async fn fetch_checkpoints(
         }
     }
 
-    let block_fetch_checkpoint = match checkpoint_db.get_checkpoint_by_idx(latest_checkpoint).await
+    let block_fetch_checkpoint = match checkpoint_db
+        .get_checkpoint_by_idx(u64::from(latest_checkpoint))
+        .await
     {
         Some(checkpoint) => Some(checkpoint),
         None => match checkpoint_db.get_latest_checkpoint_index().await {
@@ -69,7 +71,7 @@ async fn fetch_checkpoints(
     };
 
     if let Some(checkpoint) = block_fetch_checkpoint {
-        let _ = tx.send(checkpoint.l2_range.1);
+        let _ = tx.send(checkpoint.l2_end);
     }
 
     Ok(())
@@ -85,23 +87,30 @@ async fn get_starting_checkpoint_idx(db: Arc<DatabaseWrapper>) -> anyhow::Result
     let last_block = block_db.get_latest_block_index().await;
 
     let local_last_checkpoint = match checkpoint_db.get_latest_checkpoint_index().await {
-        Some(idx) => idx,
+        Some(idx) => checkpoint_idx_to_epoch(idx)?,
         // no checkpoints in db yet — start from the beginning
         None => return Ok(0),
     };
 
     // we are calling it probable_* to consider some weirdest condition when
     // we have the block but no any earlier checkpoint (before where block corresponds)
-    let probable_starting_checkpoint: u32 = if let Some(block_height) = last_block {
+    let probable_starting_checkpoint = if let Some(block_height) = last_block {
         checkpoint_db
             .get_checkpoint_idx_by_block_height(block_height)
             .await?
+            .map(checkpoint_idx_to_epoch)
+            .transpose()?
             .unwrap_or(0)
     } else {
         0
     };
 
     Ok(min(probable_starting_checkpoint, local_last_checkpoint))
+}
+
+fn checkpoint_idx_to_epoch(idx: u64) -> anyhow::Result<u32> {
+    u32::try_from(idx)
+        .map_err(|_| anyhow::anyhow!("checkpoint index exceeds RPC epoch range: {idx}"))
 }
 
 /// This function starts the checkpoint status updater task
@@ -198,7 +207,7 @@ async fn update_checkpoints_status(
     let mut idx: u32 = match status {
         RpcCheckpointConfStatus::Pending => {
             match checkpoint_db.get_earliest_pending_checkpoint_idx().await {
-                Some(i) => i,
+                Some(i) => checkpoint_idx_to_epoch(i)?,
                 None => {
                     info!("No more pending checkpoints locally.");
                     return Ok(());
@@ -207,7 +216,7 @@ async fn update_checkpoints_status(
         }
         RpcCheckpointConfStatus::Confirmed => {
             match checkpoint_db.get_earliest_confirmed_checkpoint_idx().await {
-                Some(i) => i,
+                Some(i) => checkpoint_idx_to_epoch(i)?,
                 None => {
                     info!("No more confirmed checkpoints locally.");
                     return Ok(());
@@ -218,9 +227,11 @@ async fn update_checkpoints_status(
     };
 
     while idx <= transition_boundary_idx {
+        let checkpoint_idx = u64::from(idx);
         // This is the stopping condition for the loop. If the checkpoint is not found in the database,
         // break the loop as we have already updated all the checkpoints.
-        let Some(checkpoint_in_db) = checkpoint_db.get_checkpoint_by_idx(idx).await else {
+        let Some(checkpoint_in_db) = checkpoint_db.get_checkpoint_by_idx(checkpoint_idx).await
+        else {
             info!("Status of all checkpoints in db is already updated.");
             return Ok(());
         };
@@ -247,7 +258,7 @@ async fn update_checkpoints_status(
         // update the db with the new checkpoint record instead of tweaking the existing one
         // as there could be change in both status and txid
         checkpoint_db
-            .update_checkpoint(idx, checkpoint_from_rpc)
+            .update_checkpoint(checkpoint_idx, checkpoint_from_rpc)
             .await
             .map_err(|e| {
                 error!(?e, "Failed to update checkpoint status");

--- a/backend/database/src/services/block_service.rs
+++ b/backend/database/src/services/block_service.rs
@@ -13,7 +13,7 @@ impl<'a> BlockService<'a> {
     }
 
     // TODO(STR-3791): Move header indexing into a monitored service-framework worker and return structured continuity errors instead of panicking.
-    pub async fn insert_block(&self, rpc_block_header: RpcBlockHeader, checkpoint_idx: u32) {
+    pub async fn insert_block(&self, rpc_block_header: RpcBlockHeader, checkpoint_idx: u64) {
         // Use `From` to convert `RpcBlockHeader` into an `ActiveModel`
         let mut active_model: BlockActiveModel = rpc_block_header.into();
 

--- a/backend/database/src/services/checkpoint_service.rs
+++ b/backend/database/src/services/checkpoint_service.rs
@@ -22,7 +22,7 @@ impl<'a> CheckpointService<'a> {
     }
 
     // TODO(STR-3791): Propagate database errors instead of collapsing them into false.
-    pub async fn checkpoint_exists(&self, idx: u32) -> bool {
+    pub async fn checkpoint_exists(&self, idx: u64) -> bool {
         Checkpoint::find()
             .filter(model::checkpoint::Column::Idx.eq(idx))
             .one(self.db)
@@ -33,7 +33,7 @@ impl<'a> CheckpointService<'a> {
 
     /// Insert a new checkpoint into the database
     pub async fn insert_checkpoint(&self, checkpoint: RpcCheckpointInfo) {
-        let idx: u32 = checkpoint.idx;
+        let idx = checkpoint.idx;
 
         // for the first checkpoint (idx=0), no need to check the previous checkpoint
         if let Some(previous_idx) = idx.checked_sub(1) {
@@ -58,7 +58,7 @@ impl<'a> CheckpointService<'a> {
     }
 
     /// Fetch a checkpoint by its index
-    pub async fn get_checkpoint_by_idx(&self, idx: u32) -> Option<RpcCheckpointInfoCheckpointExp> {
+    pub async fn get_checkpoint_by_idx(&self, idx: u64) -> Option<RpcCheckpointInfoCheckpointExp> {
         match Checkpoint::find()
             .filter(model::checkpoint::Column::Idx.eq(idx))
             .one(self.db)
@@ -77,7 +77,7 @@ impl<'a> CheckpointService<'a> {
     pub async fn get_checkpoint_idx_by_block_hash(
         &self,
         block_hash: &str,
-    ) -> Result<Option<u32>, DbErr> {
+    ) -> Result<Option<u64>, DbErr> {
         match Block::find()
             .filter(model::block::Column::BlockHash.eq(block_hash))
             .one(self.db)
@@ -102,7 +102,7 @@ impl<'a> CheckpointService<'a> {
     pub async fn get_checkpoint_idx_by_block_height(
         &self,
         block_height: u64,
-    ) -> Result<Option<u32>, DbErr> {
+    ) -> Result<Option<u64>, DbErr> {
         debug!(block_height, "Searching for block");
 
         match Block::find()
@@ -177,13 +177,13 @@ impl<'a> CheckpointService<'a> {
     }
 
     /// Get the latest checkpoint index stored in the database
-    pub async fn get_latest_checkpoint_index(&self) -> Option<u32> {
+    pub async fn get_latest_checkpoint_index(&self) -> Option<u64> {
         use sea_orm::entity::prelude::*;
 
         match Checkpoint::find()
             .select_only()
             .column_as(model::checkpoint::Column::Idx.max(), "max_idx")
-            .into_tuple::<Option<u32>>()
+            .into_tuple::<Option<u64>>()
             .one(self.db)
             .await
         {
@@ -197,7 +197,7 @@ impl<'a> CheckpointService<'a> {
     }
 
     /// Get the earliest checkpoint index whose status is either `Pending` or `Confirmed`
-    pub async fn get_earliest_unfinalized_checkpoint_idx(&self) -> Option<u32> {
+    pub async fn get_earliest_unfinalized_checkpoint_idx(&self) -> Option<u64> {
         // add the condition to check no checkpoint at all
         self.get_latest_checkpoint_index().await?;
         match Checkpoint::find()
@@ -215,7 +215,7 @@ impl<'a> CheckpointService<'a> {
         }
     }
     /// Get the earliest checkpoint index whose status is `Pending`
-    pub async fn get_earliest_pending_checkpoint_idx(&self) -> Option<u32> {
+    pub async fn get_earliest_pending_checkpoint_idx(&self) -> Option<u64> {
         // add the condition to check no checkpoint at all
         self.get_latest_checkpoint_index().await?;
         match Checkpoint::find()
@@ -233,7 +233,7 @@ impl<'a> CheckpointService<'a> {
         }
     }
     /// Get the earliest checkpoint index whose status is `Confirmed`
-    pub async fn get_earliest_confirmed_checkpoint_idx(&self) -> Option<u32> {
+    pub async fn get_earliest_confirmed_checkpoint_idx(&self) -> Option<u64> {
         // add the condition to check no checkpoint at all
         self.get_latest_checkpoint_index().await?;
         match Checkpoint::find()
@@ -251,7 +251,7 @@ impl<'a> CheckpointService<'a> {
         }
     }
     /// Get the last checkpoint index whose status is `Finalized`
-    pub async fn get_last_finalized_checkpoint_idx(&self) -> Option<u32> {
+    pub async fn get_last_finalized_checkpoint_idx(&self) -> Option<u64> {
         // add the condition to check no checkpoint at all
         self.get_latest_checkpoint_index().await?;
         match Checkpoint::find()
@@ -272,7 +272,7 @@ impl<'a> CheckpointService<'a> {
     /// Update the status of a checkpoint
     pub async fn update_checkpoint(
         &self,
-        checkpoint_idx: u32,
+        checkpoint_idx: u64,
         updated_checkpoint: RpcCheckpointInfo,
     ) -> Result<(), DbErr> {
         match Checkpoint::find()

--- a/backend/migration/src/lib.rs
+++ b/backend/migration/src/lib.rs
@@ -2,6 +2,7 @@ pub use sea_orm_migration::prelude::*;
 
 mod m20220101_000001_create_checkpoint_table;
 mod m20241226_100451_create_blocks_table;
+mod m20260714_000001_make_checkpoint_l2_start_nullable;
 
 pub struct Migrator;
 
@@ -11,6 +12,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20220101_000001_create_checkpoint_table::Migration),
             Box::new(m20241226_100451_create_blocks_table::Migration),
+            Box::new(m20260714_000001_make_checkpoint_l2_start_nullable::Migration),
         ]
     }
 }

--- a/backend/migration/src/m20260714_000001_make_checkpoint_l2_start_nullable.rs
+++ b/backend/migration/src/m20260714_000001_make_checkpoint_l2_start_nullable.rs
@@ -1,0 +1,44 @@
+use sea_orm_migration::{prelude::*, sea_orm::ConnectionTrait};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Checkpoints::Table)
+                    .modify_column(ColumnDef::new(Checkpoints::L2Start).big_unsigned().null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("UPDATE checkpoints SET l2_start = l2_end WHERE l2_start IS NULL")
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Checkpoints::Table)
+                    .modify_column(
+                        ColumnDef::new(Checkpoints::L2Start)
+                            .big_unsigned()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Checkpoints {
+    Table,
+    L2Start,
+}

--- a/backend/model/src/block.rs
+++ b/backend/model/src/block.rs
@@ -1,7 +1,8 @@
-use crate::checkpoint::{HexBytes32, L2BlockId};
+use crate::utils::DisplayHashHex;
 use sea_orm::entity::prelude::*;
 use sea_orm::ActiveValue::Set;
 use serde::{Deserialize, Serialize};
+use strata_identifiers::{Buf32, L2BlockId};
 
 // TODO(STR-3792): Rename block model/table abstractions to L2 block-header terminology.
 /// Represents the Block model for the database
@@ -23,7 +24,7 @@ impl ActiveModelBehavior for ActiveModel {}
 impl From<RpcBlockHeader> for ActiveModel {
     fn from(header: RpcBlockHeader) -> Self {
         Self {
-            block_hash: Set(header.blkid),
+            block_hash: Set(header.blkid.to_display_hex()),
             height: Set(header.slot),
             checkpoint_idx: Set(u64::from(header.epoch)),
         }
@@ -38,8 +39,40 @@ pub struct RpcBlockHeader {
     pub blkid: L2BlockId,
     pub timestamp: u64,
     pub parent_blkid: L2BlockId,
-    pub state_root: HexBytes32,
-    pub body_root: HexBytes32,
-    pub logs_root: HexBytes32,
+    pub state_root: Buf32,
+    pub body_root: Buf32,
+    pub logs_root: Buf32,
     pub is_terminal: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::ActiveValue::Set;
+
+    fn ascending_hex32() -> String {
+        (0u8..32).map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    #[test]
+    fn active_model_preserves_l2_block_id_byte_order() {
+        let blkid = ascending_hex32();
+        let header: RpcBlockHeader = serde_json::from_value(serde_json::json!({
+            "slot": 42,
+            "epoch": 7,
+            "blkid": blkid,
+            "timestamp": 1_700_000_000u64,
+            "parent_blkid": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "state_root": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "body_root": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "logs_root": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "is_terminal": true,
+        }))
+        .expect("test block header should deserialize");
+
+        let active_model: ActiveModel = header.into();
+
+        assert_eq!(active_model.block_hash, Set(blkid));
+        assert_eq!(active_model.checkpoint_idx, Set(7));
+    }
 }

--- a/backend/model/src/block.rs
+++ b/backend/model/src/block.rs
@@ -11,7 +11,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub block_hash: String,
     pub height: u64,
-    pub checkpoint_idx: u32,
+    pub checkpoint_idx: u64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -25,7 +25,7 @@ impl From<RpcBlockHeader> for ActiveModel {
         Self {
             block_hash: Set(header.blkid),
             height: Set(header.slot),
-            checkpoint_idx: Set(header.epoch),
+            checkpoint_idx: Set(u64::from(header.epoch)),
         }
     }
 }

--- a/backend/model/src/checkpoint.rs
+++ b/backend/model/src/checkpoint.rs
@@ -1,3 +1,4 @@
+use crate::utils::DisplayHashHex;
 use anyhow::Error;
 use sea_orm::entity::prelude::*;
 use sea_orm::ActiveValue::Set;
@@ -5,12 +6,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::result::Result;
 use std::str::FromStr;
-use strata_identifiers::EpochCommitment;
-/// Represents an L2 Block ID.
-pub type L2BlockId = String;
-pub type L1BlockId = String;
+use strata_identifiers::{EpochCommitment, L1BlockCommitment, L2BlockCommitment, RBuf32};
+
 pub type Txid = String;
-pub type HexBytes32 = String;
 
 /// The L2 slot number up to which the block fetcher should fetch blocks.
 /// Sent over the watch channel from the checkpoint fetcher to the block fetcher.
@@ -38,8 +36,8 @@ pub struct RpcCheckpointInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RpcCheckpointL1Ref {
     pub l1_block: L1BlockCommitment,
-    pub txid: Txid,
-    pub wtxid: Txid,
+    pub txid: RBuf32,
+    pub wtxid: RBuf32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -48,18 +46,6 @@ enum ConfStatus {
     Pending,
     Confirmed { l1_reference: RpcCheckpointL1Ref },
     Finalized { l1_reference: RpcCheckpointL1Ref },
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct L1BlockCommitment {
-    pub height: u64,
-    pub blkid: L1BlockId,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct L2BlockCommitment {
-    pub slot: u64,
-    pub blkid: L2BlockId,
 }
 
 /// Wire type for strata_getChainStatus (only fields we use).
@@ -138,11 +124,11 @@ impl RpcCheckpointInfo {
         }
     }
 
-    pub fn checkpoint_txid(&self) -> Option<&Txid> {
+    pub fn checkpoint_txid(&self) -> Option<Txid> {
         match &self.confirmation_status {
             ConfStatus::Pending => None,
             ConfStatus::Confirmed { l1_reference } | ConfStatus::Finalized { l1_reference } => {
-                Some(&l1_reference.txid)
+                Some(l1_reference.txid.to_display_hex())
             }
         }
     }
@@ -154,17 +140,17 @@ impl From<RpcCheckpointInfo> for ActiveModel {
             ConfStatus::Pending => (RpcCheckpointConfStatus::Pending, None),
             ConfStatus::Confirmed { l1_reference } => (
                 RpcCheckpointConfStatus::Confirmed,
-                Some(l1_reference.txid.clone()),
+                Some(l1_reference.txid.to_display_hex()),
             ),
             ConfStatus::Finalized { l1_reference } => (
                 RpcCheckpointConfStatus::Finalized,
-                Some(l1_reference.txid.clone()),
+                Some(l1_reference.txid.to_display_hex()),
             ),
         };
         Self {
             idx: Set(info.idx),
-            l1_start: Set(info.l1_range.0.height),
-            l1_end: Set(info.l1_range.1.height),
+            l1_start: Set(u64::from(info.l1_range.0.height)),
+            l1_end: Set(u64::from(info.l1_range.1.height)),
             l2_start: Set(info.l2_start.map(|commitment| commitment.slot)),
             l2_end: Set(info.l2_end.slot),
             checkpoint_txid: Set(txid),
@@ -219,15 +205,27 @@ mod tests {
     use super::*;
     use sea_orm::ActiveValue::Set;
 
+    fn hex32(byte: u8) -> String {
+        format!("{byte:02x}").repeat(32)
+    }
+
+    fn ascending_hex32() -> String {
+        (0u8..32).map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    fn descending_hex32() -> String {
+        (0u8..32).rev().map(|byte| format!("{byte:02x}")).collect()
+    }
+
     fn checkpoint_json(status: serde_json::Value) -> serde_json::Value {
         serde_json::json!({
             "idx": 7,
             "l1_range": [
-                {"height": 70, "blkid": "l1-start"},
-                {"height": 79, "blkid": "l1-end"}
+                {"height": 70, "blkid": hex32(1)},
+                {"height": 79, "blkid": hex32(2)}
             ],
-            "l2_start": {"slot": 700, "blkid": "l2-start"},
-            "l2_end": {"slot": 799, "blkid": "l2-end"},
+            "l2_start": {"slot": 700, "blkid": hex32(3)},
+            "l2_end": {"slot": 799, "blkid": hex32(4)},
             "confirmation_status": status
         })
     }
@@ -236,9 +234,9 @@ mod tests {
         serde_json::json!({
             "status": "confirmed",
             "l1_reference": {
-                "l1_block": {"height": 79, "blkid": "l1-end"},
+                "l1_block": {"height": 79, "blkid": hex32(2)},
                 "txid": txid,
-                "wtxid": "wtxid"
+                "wtxid": hex32(0x33)
             }
         })
     }
@@ -247,9 +245,9 @@ mod tests {
         serde_json::json!({
             "status": "finalized",
             "l1_reference": {
-                "l1_block": {"height": 79, "blkid": "l1-end"},
+                "l1_block": {"height": 79, "blkid": hex32(2)},
                 "txid": txid,
-                "wtxid": "wtxid"
+                "wtxid": hex32(0x33)
             }
         })
     }
@@ -266,38 +264,38 @@ mod tests {
 
     #[test]
     fn checkpoint_txid_is_exposed_for_confirmed_and_finalized() {
+        let confirmed_txid = ascending_hex32();
+        let finalized_txid = descending_hex32();
         let confirmed: RpcCheckpointInfo =
-            serde_json::from_value(checkpoint_json(confirmed_status("confirmed-txid")))
+            serde_json::from_value(checkpoint_json(confirmed_status(&confirmed_txid)))
                 .expect("confirmed checkpoint should deserialize");
         let finalized: RpcCheckpointInfo =
-            serde_json::from_value(checkpoint_json(finalized_status("finalized-txid")))
+            serde_json::from_value(checkpoint_json(finalized_status(&finalized_txid)))
                 .expect("finalized checkpoint should deserialize");
 
         assert_eq!(confirmed.status(), RpcCheckpointConfStatus::Confirmed);
         assert_eq!(
-            confirmed.checkpoint_txid().map(String::as_str),
-            Some("confirmed-txid")
+            confirmed.checkpoint_txid().as_deref(),
+            Some(confirmed_txid.as_str())
         );
         assert_eq!(finalized.status(), RpcCheckpointConfStatus::Finalized);
         assert_eq!(
-            finalized.checkpoint_txid().map(String::as_str),
-            Some("finalized-txid")
+            finalized.checkpoint_txid().as_deref(),
+            Some(finalized_txid.as_str())
         );
     }
 
     #[test]
     fn active_model_sets_checkpoint_txid_for_confirmed_checkpoint() {
+        let confirmed_txid = ascending_hex32();
         let checkpoint: RpcCheckpointInfo =
-            serde_json::from_value(checkpoint_json(confirmed_status("confirmed-txid")))
+            serde_json::from_value(checkpoint_json(confirmed_status(&confirmed_txid)))
                 .expect("confirmed checkpoint should deserialize");
 
         let active_model: ActiveModel = checkpoint.into();
 
         assert_eq!(active_model.status, Set(RpcCheckpointConfStatus::Confirmed));
-        assert_eq!(
-            active_model.checkpoint_txid,
-            Set(Some("confirmed-txid".to_string()))
-        );
+        assert_eq!(active_model.checkpoint_txid, Set(Some(confirmed_txid)));
     }
 
     #[test]

--- a/backend/model/src/checkpoint.rs
+++ b/backend/model/src/checkpoint.rs
@@ -21,11 +21,17 @@ pub type L2BlockFetchTarget = u64;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RpcCheckpointInfo {
     /// The index of the checkpoint
-    pub idx: u32,
+    pub idx: u64,
+
     /// The L1 height range that the checkpoint covers (start, end)
     pub l1_range: (L1BlockCommitment, L1BlockCommitment),
-    /// The L2 height range that the checkpoint covers (start, end)
-    pub l2_range: (L2BlockCommitment, L2BlockCommitment),
+
+    /// The first L2 block that the checkpoint covers, if known.
+    pub l2_start: Option<L2BlockCommitment>,
+
+    /// The last L2 block that the checkpoint covers.
+    pub l2_end: L2BlockCommitment,
+
     confirmation_status: ConfStatus,
 }
 
@@ -71,9 +77,11 @@ pub enum RpcCheckpointConfStatus {
     /// Pending to be posted on L1
     #[sea_orm(string_value = "Pending")]
     Pending,
+
     /// Confirmed on L1
     #[sea_orm(string_value = "Confirmed")]
     Confirmed,
+
     /// Finalized on L1
     #[sea_orm(string_value = "Finalized")]
     Finalized,
@@ -109,10 +117,10 @@ impl Display for RpcCheckpointConfStatus {
 #[sea_orm(table_name = "checkpoints")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
-    pub idx: u32,
+    pub idx: u64,
     pub l1_start: u64,
     pub l1_end: u64,
-    pub l2_start: u64,
+    pub l2_start: Option<u64>,
     pub l2_end: u64,
     pub checkpoint_txid: Option<Txid>,
     pub status: RpcCheckpointConfStatus,
@@ -157,8 +165,8 @@ impl From<RpcCheckpointInfo> for ActiveModel {
             idx: Set(info.idx),
             l1_start: Set(info.l1_range.0.height),
             l1_end: Set(info.l1_range.1.height),
-            l2_start: Set(info.l2_range.0.slot),
-            l2_end: Set(info.l2_range.1.slot),
+            l2_start: Set(info.l2_start.map(|commitment| commitment.slot)),
+            l2_end: Set(info.l2_end.slot),
             checkpoint_txid: Set(txid),
             status: Set(status),
         }
@@ -175,13 +183,20 @@ pub struct ExplorerL1Ref {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RpcCheckpointInfoCheckpointExp {
     /// The index of the checkpoint
-    pub idx: u32,
+    pub idx: u64,
+
     /// The L1 height range that the checkpoint covers (start, end)
     pub l1_range: (u64, u64),
-    /// The L2 height range that the checkpoint covers (start, end)
-    pub l2_range: (u64, u64),
+
+    /// The first L2 block that the checkpoint covers, if known.
+    pub l2_start: Option<u64>,
+
+    /// The last L2 block that the checkpoint covers.
+    pub l2_end: u64,
+
     /// Txid of the L1 transaction where the checkpoint was committed (None if not yet committed)
     pub l1_reference: Option<ExplorerL1Ref>,
+
     /// Confirmation status of checkpoint
     pub confirmation_status: Option<RpcCheckpointConfStatus>,
 }
@@ -191,7 +206,8 @@ impl From<Model> for RpcCheckpointInfoCheckpointExp {
         Self {
             idx: model.idx,
             l1_range: (model.l1_start, model.l1_end),
-            l2_range: (model.l2_start, model.l2_end),
+            l2_start: model.l2_start,
+            l2_end: model.l2_end,
             l1_reference: model.checkpoint_txid.map(|txid| ExplorerL1Ref { txid }),
             confirmation_status: Some(model.status),
         }
@@ -210,10 +226,8 @@ mod tests {
                 {"height": 70, "blkid": "l1-start"},
                 {"height": 79, "blkid": "l1-end"}
             ],
-            "l2_range": [
-                {"slot": 700, "blkid": "l2-start"},
-                {"slot": 799, "blkid": "l2-end"}
-            ],
+            "l2_start": {"slot": 700, "blkid": "l2-start"},
+            "l2_end": {"slot": 799, "blkid": "l2-end"},
             "confirmation_status": status
         })
     }
@@ -284,5 +298,20 @@ mod tests {
             active_model.checkpoint_txid,
             Set(Some("confirmed-txid".to_string()))
         );
+    }
+
+    #[test]
+    fn checkpoint_l2_start_can_be_absent() {
+        let mut json = checkpoint_json(serde_json::json!({"status": "pending"}));
+        json["l2_start"] = serde_json::Value::Null;
+
+        let checkpoint: RpcCheckpointInfo =
+            serde_json::from_value(json).expect("checkpoint without l2_start should deserialize");
+
+        assert_eq!(checkpoint.l2_start, None);
+
+        let active_model: ActiveModel = checkpoint.into();
+        assert_eq!(active_model.l2_start, Set(None));
+        assert_eq!(active_model.l2_end, Set(799));
     }
 }

--- a/backend/model/src/lib.rs
+++ b/backend/model/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod block;
 pub mod checkpoint;
+mod utils;

--- a/backend/model/src/utils.rs
+++ b/backend/model/src/utils.rs
@@ -1,0 +1,72 @@
+//! Hex encoding helpers for validated hash identifier types.
+
+use strata_identifiers::{L2BlockId, RBuf32};
+
+/// Converts a validated hash identifier to the full hex string used by the explorer API.
+///
+/// The output is non-truncated and follows the identifier's display convention:
+/// OL identifiers use normal byte order, while Bitcoin [`RBuf32`] values use
+/// Bitcoin explorer/bitcoin-cli display order.
+pub(crate) trait DisplayHashHex {
+    fn to_display_hex(&self) -> String;
+}
+
+impl DisplayHashHex for L2BlockId {
+    fn to_display_hex(&self) -> String {
+        full_hash_hex(self.as_ref())
+    }
+}
+
+impl DisplayHashHex for RBuf32 {
+    fn to_display_hex(&self) -> String {
+        bitcoin_hash_hex(self.as_ref())
+    }
+}
+
+/// Converts raw hash bytes into full lowercase hex.
+fn full_hash_hex(bytes: &[u8; 32]) -> String {
+    hex::encode(bytes)
+}
+
+/// Converts raw Bitcoin hash bytes into the explorer/bitcoin-cli display order.
+///
+/// Bitcoin txids and block hashes are conventionally displayed with the byte
+/// order reversed from the internal hash byte order stored by [`strata_identifiers::RBuf32`].
+fn bitcoin_hash_hex(bytes: &[u8; 32]) -> String {
+    let mut display_bytes = *bytes;
+    // Preserve Bitcoin explorer link compatibility by storing display-order hex.
+    display_bytes.reverse();
+    full_hash_hex(&display_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use strata_identifiers::Buf32;
+
+    fn ascending_hex32() -> String {
+        (0u8..32).map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    fn descending_hex32() -> String {
+        (0u8..32).rev().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    #[test]
+    fn l2_block_id_display_hex_preserves_byte_order() {
+        let hex = ascending_hex32();
+        let id = L2BlockId::from(Buf32::from_str(&hex).expect("test hash should parse"));
+
+        assert_eq!(id.to_display_hex(), hex);
+    }
+
+    #[test]
+    fn bitcoin_hash_display_hex_reverses_byte_order() {
+        let internal_hex = ascending_hex32();
+        let internal_hash = Buf32::from_str(&internal_hex).expect("test bitcoin hash should parse");
+        let txid = RBuf32::from(*internal_hash.as_ref());
+
+        assert_eq!(txid.to_display_hex(), descending_hex32());
+    }
+}

--- a/frontend/src/components/CheckpointDetails/index.tsx
+++ b/frontend/src/components/CheckpointDetails/index.tsx
@@ -95,13 +95,13 @@ const CheckpointDetails = () => {
         <div className={styles.checkpointRow}>
           <span className={styles.checkpointLabel}>Strata start block:</span>
           <span className={styles.checkpointValue}>
-            {checkpoint.l2_range[0]}
+            {checkpoint.l2_start ?? "N/A"}
           </span>
         </div>
         <div className={styles.checkpointRow}>
           <span className={styles.checkpointLabel}>Strata end block:</span>
           <span className={styles.checkpointValue}>
-            {checkpoint.l2_range[1]}
+            {checkpoint.l2_end}
           </span>
         </div>
       </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -25,14 +25,14 @@ const Header = () => {
         <nav className={styles.navMenu} role="navigation">
           <div className={styles.navLinks}>
             <a
-              href="https://alpenlabs.io/"
+              href="https://alpen.org"
               target="_blank"
               className={styles.navLink}
             >
               Home
             </a>
             <a
-              href="https://docs.alpenlabs.io/"
+              href="https://docs.alpen.org"
               target="_blank"
               className={styles.navLink}
             >

--- a/frontend/src/components/Table/TableBody/index.tsx
+++ b/frontend/src/components/Table/TableBody/index.tsx
@@ -119,10 +119,10 @@ const TableBody: React.FC = () => {
                   </a>
                 </td>
                 <td className={styles.tableCell}>
-                  {checkpoint.l2_range[0]}
+                  {checkpoint.l2_start ?? "N/A"}
                 </td>
                 <td className={styles.tableCell}>
-                  {checkpoint.l2_range[1]}
+                  {checkpoint.l2_end}
                 </td>
               </tr>
             ))}

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -2,8 +2,8 @@
 export interface RpcCheckpointInfoCheckpointExp {
   idx: number; // Index of the checkpoint
   l1_range: [number, number]; // L1 height range (start, end)
-  l2_range: [number, number]; // L2 height range (start, end)
-  l2_blockid: string; // L2 block ID
+  l2_start: number | null; // First L2 block, if known
+  l2_end: number; // Last L2 block
   l1_reference?: CheckpointL1Ref;
   confirmation_status?: string;
 }

--- a/frontend/src/utils/lib.tsx
+++ b/frontend/src/utils/lib.tsx
@@ -23,9 +23,10 @@ function isRpcCheckpointInfo(
     "l1_range" in first &&
     Array.isArray(first.l1_range) &&
     first.l1_range.length === 2 &&
-    "l2_range" in first &&
-    Array.isArray(first.l2_range) &&
-    first.l2_range.length === 2
+    "l2_start" in first &&
+    (typeof first.l2_start === "number" || first.l2_start === null) &&
+    "l2_end" in first &&
+    typeof first.l2_end === "number"
   );
 }
 function reverseEndian(value: string | null | undefined): string {

--- a/functional-tests/envs/services/mock_fullnode.py
+++ b/functional-tests/envs/services/mock_fullnode.py
@@ -90,6 +90,13 @@ class _MockServer(ThreadingHTTPServer):
         l2_end = l2_start + self._bpc - 1
         l1_start = idx * 10
         l1_end = l1_start + 9
+        # Exercise the nullable `l2_start` path; real checkpoint-sync nodes can return
+        # null for any non-genesis checkpoint, not specifically the latest one.
+        l2_start_commitment = (
+            None
+            if idx == self._n - 1
+            else {"slot": l2_start, "blkid": _hex(l2_start, namespace=2)}
+        )
 
         l1_ref = {
             "l1_block": {"height": l1_end, "blkid": _hex(l1_end, namespace=1)},
@@ -111,10 +118,8 @@ class _MockServer(ThreadingHTTPServer):
                 {"height": l1_start, "blkid": _hex(l1_start, namespace=1)},
                 {"height": l1_end, "blkid": _hex(l1_end, namespace=1)},
             ],
-            "l2_range": [
-                {"slot": l2_start, "blkid": _hex(l2_start, namespace=2)},
-                {"slot": l2_end, "blkid": _hex(l2_end, namespace=2)},
-            ],
+            "l2_start": l2_start_commitment,
+            "l2_end": {"slot": l2_end, "blkid": _hex(l2_end, namespace=2)},
             "confirmation_status": conf_status,
         }
 

--- a/functional-tests/tests/checkpoint_detail.py
+++ b/functional-tests/tests/checkpoint_detail.py
@@ -11,13 +11,18 @@ class CheckpointDetailTest(testenv.ExplorerTestBase):
     def main(self, ctx: flexitest.RunContext):
         client = self.get_client(ctx)
 
-        # Get a valid idx from the list
-        resp = client.get_checkpoints(page=1, page_size=1)
+        # Get a checkpoint that exercises the nullable l2_start path.
+        resp = client.get_checkpoints(page=1, page_size=10)
         items = resp["result"]["items"]
         if not items:
             return True
 
-        idx = items[0]["idx"]
+        null_l2_start_items = [item for item in items if item["l2_start"] is None]
+        known_l2_start_items = [item for item in items if item["l2_start"] is not None]
+        assert null_l2_start_items, "expected at least one checkpoint with null l2_start"
+        assert known_l2_start_items, "expected at least one checkpoint with known l2_start"
+
+        idx = null_l2_start_items[0]["idx"]
         detail_resp = client.get_checkpoint(idx)
         assert "result" in detail_resp, "response must have 'result' key"
 
@@ -29,10 +34,13 @@ class CheckpointDetailTest(testenv.ExplorerTestBase):
         cp = detail_items[0]
         assert cp["idx"] == idx, f"expected idx={idx}, got {cp['idx']}"
         assert "l1_range" in cp, "checkpoint must have 'l1_range'"
-        assert "l2_range" in cp, "checkpoint must have 'l2_range'"
+        assert "l2_start" in cp, "checkpoint must have 'l2_start'"
+        assert "l2_end" in cp, "checkpoint must have 'l2_end'"
 
         l1 = cp["l1_range"]
         assert len(l1) == 2, "l1_range must be 2 elements"
         assert l1[0] <= l1[1], "l1_range start must be <= end"
+        assert cp["l2_start"] is None, "null l2_start must round-trip through the API"
+        assert isinstance(cp["l2_end"], int), "l2_end must be an integer"
 
         return True

--- a/functional-tests/tests/checkpoints.py
+++ b/functional-tests/tests/checkpoints.py
@@ -23,13 +23,19 @@ class CheckpointsPaginationTest(testenv.ExplorerTestBase):
         if not items:
             return True
 
+        null_l2_start_items = [item for item in items if item["l2_start"] is None]
+        known_l2_start_items = [item for item in items if item["l2_start"] is not None]
+        assert null_l2_start_items, "at least one checkpoint should preserve null l2_start"
+        assert known_l2_start_items, "at least one checkpoint should preserve a known l2_start"
+
         # Validate checkpoint shape
         first = items[0]
         assert "idx" in first, "checkpoint must have 'idx'"
         assert "l1_range" in first, "checkpoint must have 'l1_range'"
-        assert "l2_range" in first, "checkpoint must have 'l2_range'"
+        assert "l2_start" in first, "checkpoint must have 'l2_start'"
+        assert "l2_end" in first, "checkpoint must have 'l2_end'"
         assert len(first["l1_range"]) == 2, "l1_range must be a 2-element list"
-        assert len(first["l2_range"]) == 2, "l2_range must be a 2-element list"
+        assert isinstance(first["l2_end"], int), "l2_end must be an integer"
 
         # Verify page 2 returns different results when enough checkpoints exist
         if len(items) == 10:


### PR DESCRIPTION
## Summary

- Support the revised `strata_getCheckpointInfo` response shape in checkpoint explorer.
- Allow `checkpoints.l2_start` to be nullable via a new DB migration and render missing values as `N/A`.
- Replace duplicate local hash/commitment wire types with validated `strata-identifiers` types.
- Preserve existing explorer hex display behavior for OL block ids and Bitcoin txids, with focused tests for byte order.
- Update header links.